### PR TITLE
Fix endpoint construction for checkout api

### DIFF
--- a/force-app/main/default/customMetadata/Adyen_Adapter.AdyenDefault.md-meta.xml
+++ b/force-app/main/default/customMetadata/Adyen_Adapter.AdyenDefault.md-meta.xml
@@ -8,7 +8,7 @@
     </values>
     <values>
         <field>Capture_Endpoint__c</field>
-        <value xsi:type="xsd:string">/{paymentPspReference}/captures</value>
+        <value xsi:type="xsd:string">/payments/{paymentPspReference}/captures</value>
     </values>
     <values>
         <field>Endpoint_Api_Version__c</field>
@@ -28,7 +28,7 @@
     </values>
     <values>
         <field>Refund_Endpoint__c</field>
-        <value xsi:type="xsd:string">/{paymentPspReference}/refunds</value>
+        <value xsi:type="xsd:string">/payments/{paymentPspReference}/refunds</value>
     </values>
     <values>
         <field>Service_Password__c</field>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixing endpoint formation through Adyen adapter custom metadata type for checkout api.
Also fixing the name that is needed for OOBO to be equal to AdyenConstants.DEFAULT_ADAPTER_NAME (since we do not fetch from payment authorization, that does not exist yet). 

**Fixed issue**:  SFI-189