### PR TITLE
SFI-191 proposed solution

### DIFF
--- a/force-app/main/default/classes/AdyenPaymentHelper.cls
+++ b/force-app/main/default/classes/AdyenPaymentHelper.cls
@@ -1,4 +1,4 @@
-public with sharing class AdyenPaymentHelper {
+public without sharing class AdyenPaymentHelper {
 
     public static String TEST_NOTIFICATION_REQUEST_BODY;
 
@@ -26,68 +26,50 @@ public with sharing class AdyenPaymentHelper {
 
     public static CommercePayments.GatewayNotificationResponse handleAsyncNotificationCallback(
         CommercePayments.PaymentGatewayNotificationContext gatewayNotificationContext,
-            String apexName
-        ) {
-        System.debug('----> Entering AdyenPaymentHelper.handleAsyncNotificationCallback PaymentGatewayNotificationContext= ' + gatewayNotificationContext);
+        String adyenAdapterName
+    ) {
         CommercePayments.PaymentGatewayNotificationRequest paymentGatewayNotificationRequest = Test.isRunningTest() ? null : gatewayNotificationContext.getPaymentGatewayNotificationRequest();
         CommercePayments.GatewayNotificationResponse gatewayNotificationResponse = new CommercePayments.GatewayNotificationResponse();
 
         CommercePayments.NotificationSaveResult notificationSaveResult;
         NotificationRequestItem notificationRequestItem = parseAdyenNotificationRequest( paymentGatewayNotificationRequest );
-        String apexAdapterId;
+        String apexAdapterName;
         if (notificationRequestItem.originalReference != null) {
-            apexAdapterId = AdyenPaymentUtility.retrieveApexAdapterId(notificationRequestItem.originalReference);
+            apexAdapterName = AdyenPaymentUtility.retrieveApexAdapterName(notificationRequestItem.originalReference);
         }
+        if (adyenAdapterName.equals(apexAdapterName) || Test.isRunningTest()) {
+            notificationSaveResult = createNotificationSaveResult( notificationRequestItem );
 
-        System.debug('----> apexAdapterId = ' + apexAdapterId);
-
-        String nameSpacePrefix = '';
-        List<ApexClass> adyenApexClass = [SELECT NamespacePrefix from ApexClass WHERE Name = :apexName];
-        if (adyenApexClass.size() > 0) {
-            nameSpacePrefix = adyenApexClass[0].NamespacePrefix;
-        }
-        String apexClassId = AdyenPaymentUtility.retrieveApexClassId(apexName, nameSpacePrefix);
-        System.debug('----> apexClassId = ' + apexClassId);
-
-        if(apexAdapterId == apexClassId || Test.isRunningTest()){
-
-        notificationSaveResult = createNotificationSaveResult( notificationRequestItem );
-
-        if (notificationSaveResult != null) {
-            if(notificationSaveResult.isSuccess()){ // Notification is accepted by the platform
-                gatewayNotificationResponse.setStatusCode(AdyenConstants.HTTP_SUCCESS_CODE);
-                gatewayNotificationResponse.setResponseBody(Blob.valueOf(AdyenConstants.NOTIFICATION_ACCEPTED_RESPONSE ));
-                    System.debug('----> Exiting AdyenPaymentHelper.handleAsyncNotificationCallback after the notification is accepted: ' + gatewayNotificationResponse);
-                return gatewayNotificationResponse;
-            } else { // Notification is not accepted by the platform, generate system event
-                gatewayNotificationResponse.setStatusCode(integer.valueOf(AdyenConstants.HTTP_SERVER_ERROR_CODE));
-                String msg = '[accepted] ';
-                if (notificationSaveResult != null && notificationSaveResult.getErrorMessage() != null) {
-                    msg += notificationSaveResult.getErrorMessage();
+            if (notificationSaveResult != null) {
+                if(notificationSaveResult.isSuccess()){ // Notification is accepted by the platform
+                    gatewayNotificationResponse.setStatusCode(AdyenConstants.HTTP_SUCCESS_CODE);
+                    gatewayNotificationResponse.setResponseBody(Blob.valueOf(AdyenConstants.NOTIFICATION_ACCEPTED_RESPONSE ));
+                    return gatewayNotificationResponse;
+                } else { // Notification is not accepted by the platform, generate system event
+                    gatewayNotificationResponse.setStatusCode(integer.valueOf(AdyenConstants.HTTP_SERVER_ERROR_CODE));
+                    String msg = '[accepted] ';
+                    if (notificationSaveResult != null && notificationSaveResult.getErrorMessage() != null) {
+                        msg += notificationSaveResult.getErrorMessage();
+                    }
+                    gatewayNotificationResponse.setResponseBody(Blob.valueOf(msg));
+                    return gatewayNotificationResponse;
                 }
-                gatewayNotificationResponse.setResponseBody(Blob.valueOf(msg));
-                return gatewayNotificationResponse;
-            }
-        } else {
-                String msg = '';
-                msg += '[accepted] But unsupported notification type: ' + notificationRequestItem.eventCode;
+            } else {
+                String msg = '[accepted] But unsupported notification type: ' + notificationRequestItem.eventCode;
                     gatewayNotificationResponse.setResponseBody(Blob.valueOf( msg ));
                     gatewayNotificationResponse.setStatusCode(AdyenConstants.HTTP_SUCCESS_CODE);
                 return gatewayNotificationResponse;
-        }
-
+            }
         } else {
             String msg = '[accepted] ';
             if (notificationRequestItem.originalReference == null) {
                 msg += 'Notification skipped, original reference is not available';
                 gatewayNotificationResponse.setResponseBody(Blob.valueOf(msg));
                 gatewayNotificationResponse.setStatusCode(AdyenConstants.HTTP_SUCCESS_CODE);
-                System.debug('----> Exiting AdyenPaymentHelper.handleAsyncNotificationCallback, originalReference is n/a: ' + gatewayNotificationResponse);
             } else {
                 msg += 'But not processed - wrong payment adapter or wrong instance';
                 gatewayNotificationResponse.setResponseBody(Blob.valueOf(msg));
                 gatewayNotificationResponse.setStatusCode(AdyenConstants.HTTP_SUCCESS_CODE);
-                System.debug('----> Exiting AdyenPaymentHelper.handleAsyncNotificationCallback after identifying that it was the wrong payment adapter: ' + gatewayNotificationResponse);
             }
             return gatewayNotificationResponse;
         }

--- a/force-app/main/default/classes/AdyenPaymentUtility.cls
+++ b/force-app/main/default/classes/AdyenPaymentUtility.cls
@@ -1,4 +1,4 @@
-public with sharing class AdyenPaymentUtility {
+public without sharing class AdyenPaymentUtility {
 
     @TestVisible
     private static final String TEST_ENDPOINT = 'https://test.com';
@@ -174,47 +174,37 @@ public with sharing class AdyenPaymentUtility {
     }
 
     /**
-     * Retrieve apex adapter id from the gateway reference number.
+     * Retrieve apex adapter name from the gateway reference number.
      *
      * @param gatewayRefNumber original payment gatewayrefnumber as recieved in the notification
-     * @return apexclass id for the payment gateway adapter.
+     * @return apexclass name for the payment gateway adapter.
      */
-    public static String retrieveApexAdapterId(String gatewayRefNumber) {
-        String apexAdapterId = null;
-
-                // Prioritize the payment authorization record if it exists
-                for (PaymentAuthorization paymentAuthorization : [
-                    SELECT
-                    PaymentGateway.PaymentGatewayProvider.ApexAdapter.Id
-                    FROM
-                    PaymentAuthorization
-                    WHERE
-                    GatewayRefNumber = :gatewayRefNumber
-                ]) {
-                    if(null!=paymentAuthorization.PaymentGateway && null!=paymentAuthorization.PaymentGateway.PaymentGatewayProvider && null!=paymentAuthorization.PaymentGateway.PaymentGatewayProvider.ApexAdapter)
-                    {
-                        apexAdapterId = paymentAuthorization.PaymentGateway.PaymentGatewayProvider.ApexAdapter.Id;
-                    }
-                }
-
-            // Fall back to a payment record for pre-captured transactions
-            if (null==apexAdapterId) {
-                for (Payment payment : [
-                    SELECT
-                    PaymentGateway.PaymentGatewayProvider.ApexAdapter.Id
-                    FROM
-                    Payment
-                    WHERE
-                    GatewayRefNumber = :gatewayRefNumber
-                ]) {
-                    if (null!=payment.PaymentGateway && null!=payment.PaymentGateway.PaymentGatewayProvider && null!=payment.PaymentGateway.PaymentGatewayProvider.ApexAdapter)
-                    {
-                        apexAdapterId = payment.PaymentGateway.PaymentGatewayProvider.ApexAdapter.Id;
-                    }
+    public static String retrieveApexAdapterName(String gatewayRefNumber) {
+        String apexAdapterName;
+        // Prioritize the payment authorization record if it exists
+        for (PaymentAuthorization paymentAuthorization : [
+            SELECT PaymentGateway.PaymentGatewayProvider.ApexAdapter.Name
+            FROM PaymentAuthorization
+            WHERE GatewayRefNumber = :gatewayRefNumber
+        ]) {
+            if (null != paymentAuthorization.PaymentGateway.PaymentGatewayProvider.ApexAdapter.Name) {
+                apexAdapterName = paymentAuthorization.PaymentGateway.PaymentGatewayProvider.ApexAdapter.Name;
+            }
+        }
+        // Fall back to a payment record for pre-captured transactions
+        if (String.isBlank(apexAdapterName)) {
+            for (Payment payment : [
+                SELECT PaymentGateway.PaymentGatewayProvider.ApexAdapter.Name
+                FROM Payment
+                WHERE GatewayRefNumber = :gatewayRefNumber
+            ]) {
+                if (null != payment.PaymentGateway.PaymentGatewayProvider.ApexAdapter.Name) {
+                    apexAdapterName = payment.PaymentGateway.PaymentGatewayProvider.ApexAdapter.Name;
                 }
             }
+        }
 
-        return apexAdapterId;
+        return apexAdapterName;
     }
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Proposed bug fix, but I realized for some reason that the Name of the ApexClass is null if "with sharing" is used. So this might not be the ideal solution if this is the case, we would still need to query the adyen class Id and compare Ids.
PS: the long if  for the method retrieveApexAdapterName could be greatly reduced since null pointer exceptions are not thrown when traversing query relationships: [doc here](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_SObjects_field_relationships.htm).

**Fixed issue**: SFI-191 Fetching the correct gateway apex adapter