### PR TITLE
Making fulfillment order number as capture reference.

### DIFF
--- a/force-app/main/default/classes/AdyenCaptureHelper.cls
+++ b/force-app/main/default/classes/AdyenCaptureHelper.cls
@@ -42,7 +42,7 @@ public with sharing class AdyenCaptureHelper {
             currencyCode,
             captureRequest.amount,
             adyenAdapterMdt.Merchant_Account__c,
-            AdyenPaymentUtility.getReference(pa)
+            AdyenPaymentUtility.getReference(pa, captureRequest.amount)
         );
 
         // For payment methods requiring Open Invoice data (e.g., Klarna), append it

--- a/force-app/main/default/classes/AdyenPaymentUtility.cls
+++ b/force-app/main/default/classes/AdyenPaymentUtility.cls
@@ -323,23 +323,31 @@ public with sharing class AdyenPaymentUtility {
         return String.valueOf(Math.round(Math.random() * MAX)).leftPad(stringLength, '0');
     }
 
-    public static FulfillmentOrder getFulfillmentOrder(Id orderSummaryId) {
-        FulfillmentOrder fulfillmentOrder;
+    public static FulfillmentOrder getFulfillmentOrder(Id orderSummaryId, Double amount) {
         try {
-            fulfillmentOrder = [
-                SELECT FulfillmentOrderNumber, Status, StatusCategory, Type, TypeCategory
+            List<FulfillmentOrder> fulfillmentOrders = [
+                SELECT FulfillmentOrderNumber, Status, StatusCategory, Type, TypeCategory, GrandTotalAmount
                 FROM FulfillmentOrder
                 WHERE OrderSummaryId = :orderSummaryId
+                ORDER BY CreatedDate DESC
             ];
+            for (FulfillmentOrder fulfillmentOrder : fulfillmentOrders) {
+                if (fulfillmentOrder.GrandTotalAmount == amount) {
+                    return fulfillmentOrder;
+                }
+            }
+            throw new AdyenAsyncAdapter.GatewayException(
+                'Cannot find any fulfillment order related to order summary Id ' + orderSummaryId + ' with amount ' + amount
+            );
         } catch (Exception ex) {
             logException(ex, LoggingLevel.ERROR);
         }
-        return fulfillmentOrder;
+        return null;
     }
 
-    public static String getReference(SObject anyPaymentTypeRecord) {
+    public static String getReference(SObject anyPaymentTypeRecord, Double amount) {
         Id orderSummaryId = ((OrderPaymentSummary)anyPaymentTypeRecord.getSObject('OrderPaymentSummary')).OrderSummaryId;
-        String reference = getFulfillmentOrder(orderSummaryId)?.FulfillmentOrderNumber;
+        String reference = getFulfillmentOrder(orderSummaryId, amount)?.FulfillmentOrderNumber;
         return String.isNotBlank(reference) ? reference : getRandomNumber(16);
     }
 

--- a/force-app/main/default/classes/AdyenPaymentUtilityTest.cls
+++ b/force-app/main/default/classes/AdyenPaymentUtilityTest.cls
@@ -89,7 +89,7 @@ private class AdyenPaymentUtilityTest {
     static void getFulfillmentOrderTest() {
         OrderPaymentSummary orderPaySum = createInvoiceAndRelatedRecords(100, 5);
         Test.startTest();
-        FulfillmentOrder fulfillmentOrder = AdyenPaymentUtility.getFulfillmentOrder(orderPaySum.OrderSummaryId);
+        FulfillmentOrder fulfillmentOrder = AdyenPaymentUtility.getFulfillmentOrder(orderPaySum.OrderSummaryId, 105);
         Test.stopTest();
         Assert.isNotNull(fulfillmentOrder);
     }
@@ -97,7 +97,7 @@ private class AdyenPaymentUtilityTest {
     @IsTest
     static void getFulfillmentOrderFailTest() {
         Test.startTest();
-        FulfillmentOrder fulfillmentOrder = AdyenPaymentUtility.getFulfillmentOrder(null);
+        FulfillmentOrder fulfillmentOrder = AdyenPaymentUtility.getFulfillmentOrder(null, 0);
         Test.stopTest();
         Assert.isNull(fulfillmentOrder);
     }
@@ -122,8 +122,8 @@ private class AdyenPaymentUtilityTest {
         ];
 
         Test.startTest();
-        String referencePayAuth = AdyenPaymentUtility.getReference(payAuth);
-        String referencePayment = AdyenPaymentUtility.getReference(payment);
+        String referencePayAuth = AdyenPaymentUtility.getReference(payAuth, 105);
+        String referencePayment = AdyenPaymentUtility.getReference(payment, 105);
         Test.stopTest();
 
         Assert.areEqual(fulfillmentOrder.FulfillmentOrderNumber, referencePayAuth);
@@ -136,7 +136,7 @@ private class AdyenPaymentUtilityTest {
         PaymentAuthorization payAuth = new PaymentAuthorization(OrderPaymentSummary = orderPaymentSummary);
 
         Test.startTest();
-        String reference = AdyenPaymentUtility.getReference(payAuth);
+        String reference = AdyenPaymentUtility.getReference(payAuth, 23);
         Test.stopTest();
 
         Assert.isNotNull(reference);

--- a/force-app/main/default/classes/AdyenRefundHelper.cls
+++ b/force-app/main/default/classes/AdyenRefundHelper.cls
@@ -43,7 +43,7 @@ public with sharing class AdyenRefundHelper {
             CommercePayments.RequestType.ReferencedRefund,
             currencyCode, refundRequest.amount,
             adyenAdapterMdt.Merchant_Account__c,
-            AdyenPaymentUtility.getReference(payment)
+            AdyenPaymentUtility.getRandomNumber(16)
         );
         //Only for Paypal Refunds - Capture reference must be a substring of refund reference
         if (String.isNotBlank(payment.PaymentAuthorization.Adyen_Payment_Method_Variant__c)) {


### PR DESCRIPTION

## Summary
This PR set as capture reference property the related fulfillment order number. For more information consult this ticket [SFI-280](https://youtrack.is.adyen.com/issue/SFI-280/Send-Order-Reference-on-Capture-Requests)