### PR TITLE
Changing names to avoid conflict during upgrade

### DIFF
--- a/force-app/main/default/classes/AdyenAuthorisationHelperTest.cls
+++ b/force-app/main/default/classes/AdyenAuthorisationHelperTest.cls
@@ -90,7 +90,7 @@ private class AdyenAuthorisationHelperTest {
             AdyenAuthorisationHelper.authorise(TestDataFactory.createAuthorisationRequest(null));
             Assert.fail();
         } catch (Exception ex) {
-            Assert.isInstanceOfType(ex, AdyenAsyncAdapter.GatewayException.class);
+            Assert.isInstanceOfType(ex, AdyenGatewayAdapter.GatewayException.class);
             Assert.isTrue(ex.getMessage().containsIgnoreCase('400'));
         }
         Test.stopTest();

--- a/force-app/main/default/classes/AdyenCaptureHelper.cls
+++ b/force-app/main/default/classes/AdyenCaptureHelper.cls
@@ -17,7 +17,7 @@ public with sharing class AdyenCaptureHelper {
             errorMessage = 'Payment Amount Missing';
         }
         if (String.isNotBlank(errorMessage)) {
-            throw new AdyenAsyncAdapter.GatewayException(errorMessage);
+            throw new AdyenGatewayAdapter.GatewayException(errorMessage);
         }
 
         String pspReference = paymentAuth.GatewayRefNumber;

--- a/force-app/main/default/classes/AdyenGatewayAdapter.cls
+++ b/force-app/main/default/classes/AdyenGatewayAdapter.cls
@@ -1,11 +1,6 @@
-/**
- *  This class is being deprecated after v2 due to the introduction of the payment gateway provider metadata.
- *  This way when upgrading the package conflicts will be avoided.
- *  The new one should be AdyenGatewayAdapter.
- */
-global with sharing class AdyenAsyncAdapter implements CommercePayments.PaymentGatewayAdapter, CommercePayments.PaymentGatewayAsyncAdapter {
+global with sharing class AdyenGatewayAdapter implements CommercePayments.PaymentGatewayAdapter, CommercePayments.PaymentGatewayAsyncAdapter {
 
-    global AdyenAsyncAdapter() {}
+    global AdyenGatewayAdapter() {}
 
     global CommercePayments.GatewayResponse processRequest(CommercePayments.PaymentGatewayContext paymentGatewayContext) {
         try {

--- a/force-app/main/default/classes/AdyenGatewayAdapter.cls-meta.xml
+++ b/force-app/main/default/classes/AdyenGatewayAdapter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/AdyenGatewayAdapterTest.cls
+++ b/force-app/main/default/classes/AdyenGatewayAdapterTest.cls
@@ -1,0 +1,131 @@
+@IsTest
+private class AdyenGatewayAdapterTest {
+    @TestSetup
+    static void makeData() {
+        Account acct = TestDataFactory.createAccount();
+        insert acct;
+        TestDataFactory.insertBasicPaymentRecords(acct.Id, null);
+    }
+
+    @IsTest
+    static void testCaptureOutboundSuccess() {
+        Test.setMock(HttpCalloutMock.class, new TestDataFactory.EchoHttpMock());
+
+        Test.startTest();
+        Id authId = [SELECT Id FROM PaymentAuthorization ORDER BY CreatedDate DESC LIMIT 1].Id;
+        CommercePayments.CaptureRequest captureRequest = new CommercePayments.CaptureRequest(TestDataFactory.TEST_AMOUNT, authId);
+        CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(captureRequest, CommercePayments.RequestType.Capture);
+        CommercePayments.GatewayResponse captureResponse = TestDataFactory.adyenAdapter.processRequest(context);
+        Test.stopTest();
+
+        Assert.isTrue(captureResponse.toString().contains('[capture-received]'));
+        Assert.isTrue(captureResponse.toString().contains(TestDataFactory.TEST_PSP_REFERENCE));
+    }
+
+    @IsTest
+    static void testCaptureOutboundFailure() {
+        Test.setMock(HttpCalloutMock.class, new TestDataFactory.FailureResponse());
+
+        Test.startTest();
+        Id authId = [SELECT Id FROM PaymentAuthorization ORDER BY CreatedDate DESC LIMIT 1].Id;
+        CommercePayments.CaptureRequest captureRequest = new CommercePayments.CaptureRequest(TestDataFactory.TEST_AMOUNT, authId);
+        CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(captureRequest, CommercePayments.RequestType.Capture);
+        CommercePayments.GatewayResponse gatewayResponse = TestDataFactory.adyenAdapter.processRequest(context);
+        Test.stopTest();
+
+        Assert.isInstanceOfType(gatewayResponse, CommercePayments.GatewayErrorResponse.class);
+        Assert.isTrue(gatewayResponse.toString().containsIgnoreCase('400'));
+    }
+
+    @IsTest
+    static void testCaptureOutboundMissingPaymentAuthorization() {
+        Test.setMock(HttpCalloutMock.class, new TestDataFactory.EchoHttpMock());
+
+        Test.startTest();
+        CommercePayments.CaptureRequest captureRequest = new CommercePayments.CaptureRequest(TestDataFactory.TEST_AMOUNT, null);
+        CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(captureRequest, CommercePayments.RequestType.Capture);
+        CommercePayments.GatewayResponse gatewayResponse = TestDataFactory.adyenAdapter.processRequest(context);
+        Test.stopTest();
+
+        Assert.isInstanceOfType(gatewayResponse, CommercePayments.GatewayErrorResponse.class);
+        Assert.isTrue(gatewayResponse.toString().containsIgnoreCase(AdyenPaymentUtility.NO_PAYMENT_AUTH_FOUND_BY_ID));
+    }
+
+    @IsTest
+    static void testCaptureOutboundMissingAmount() {
+        Test.setMock(HttpCalloutMock.class, new TestDataFactory.EchoHttpMock());
+        Id authId = [SELECT Id FROM PaymentAuthorization ORDER BY CreatedDate DESC LIMIT 1].Id;
+        Test.startTest();
+        CommercePayments.CaptureRequest captureRequest = new CommercePayments.CaptureRequest(null, authId);
+        CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(captureRequest, CommercePayments.RequestType.Capture);
+        CommercePayments.GatewayResponse gatewayResponse = TestDataFactory.adyenAdapter.processRequest(context);
+        Test.stopTest();
+        Assert.isInstanceOfType(gatewayResponse, CommercePayments.GatewayErrorResponse.class);
+        Assert.isTrue(gatewayResponse.toString().containsIgnoreCase('Payment Amount Missing'));
+    }
+
+    @IsTest
+    static void testCaptureInboundSuccess() {
+        AdyenPaymentHelper.TEST_NOTIFICATION_REQUEST_BODY = TestDataFactory.createNotificationRequestBody('CAPTURE', TestDataFactory.TEST_PSP_REFERENCE);
+
+        Test.startTest();
+        CommercePayments.GatewayNotificationResponse captureResponse = TestDataFactory.adyenAdapter.processNotification(null);
+        Test.stopTest();
+
+        Assert.isFalse(captureResponse.toString().containsIgnoreCase('error'));
+    }
+
+    @IsTest
+    static void testRefundOutboundSuccess() {
+        Test.setMock(HttpCalloutMock.class, new TestDataFactory.EchoHttpMock());
+
+        Test.startTest();
+        Id paymentId = [SELECT Id FROM Payment ORDER BY CreatedDate DESC LIMIT 1].Id;
+        CommercePayments.ReferencedRefundRequest refundRequest = new CommercePayments.ReferencedRefundRequest(TestDataFactory.TEST_AMOUNT, paymentId);
+        CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(refundRequest, CommercePayments.RequestType.ReferencedRefund);
+        CommercePayments.GatewayResponse refundResponse = TestDataFactory.adyenAdapter.processRequest(context);
+        Test.stopTest();
+
+        Assert.isTrue(refundResponse.toString().contains('received'));
+    }
+
+    @IsTest
+    static void testRefundOutboundFailure() {
+        Test.setMock(HttpCalloutMock.class, new TestDataFactory.FailureResponse());
+
+        Test.startTest();
+        Id paymentId = [SELECT Id FROM Payment ORDER BY CreatedDate DESC LIMIT 1].Id;
+        CommercePayments.ReferencedRefundRequest refundRequest = new CommercePayments.ReferencedRefundRequest(TestDataFactory.TEST_AMOUNT, paymentId);
+        CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(refundRequest, CommercePayments.RequestType.ReferencedRefund);
+        CommercePayments.GatewayResponse refundResponse = TestDataFactory.adyenAdapter.processRequest(context);
+        Test.stopTest();
+
+        Assert.isInstanceOfType(refundResponse, CommercePayments.GatewayErrorResponse.class);
+        Assert.isTrue(refundResponse.toString().containsIgnoreCase('400'));
+    }
+
+    @IsTest
+    static void testRefundOutboundMissingPayment() {
+        Test.setMock(HttpCalloutMock.class, new TestDataFactory.EchoHttpMock());
+        Test.startTest();
+        CommercePayments.ReferencedRefundRequest refundRequest = new CommercePayments.ReferencedRefundRequest(TestDataFactory.TEST_AMOUNT, null);
+        CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(refundRequest, CommercePayments.RequestType.ReferencedRefund);
+        CommercePayments.GatewayResponse gatewayResponse = TestDataFactory.adyenAdapter.processRequest(context);
+        Test.stopTest();
+        Assert.isInstanceOfType(gatewayResponse, CommercePayments.GatewayErrorResponse.class);
+        Assert.isTrue(gatewayResponse.toString().containsIgnoreCase(AdyenPaymentUtility.NO_PAYMENT_FOUND_BY_ID));
+    }
+
+    @IsTest
+    static void testRefundOutboundMissingAmount() {
+        Test.setMock(HttpCalloutMock.class, new TestDataFactory.EchoHttpMock());
+        Id paymentId = [SELECT Id FROM Payment ORDER BY CreatedDate DESC LIMIT 1].Id;
+        Test.startTest();
+        CommercePayments.ReferencedRefundRequest refundRequest = new CommercePayments.ReferencedRefundRequest(null, paymentId);
+        CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(refundRequest, CommercePayments.RequestType.ReferencedRefund);
+        CommercePayments.GatewayResponse gatewayResponse = TestDataFactory.adyenAdapter.processRequest(context);
+        Test.stopTest();
+        Assert.isInstanceOfType(gatewayResponse, CommercePayments.GatewayErrorResponse.class);
+        Assert.isTrue(gatewayResponse.toString().containsIgnoreCase('Payment Amount Missing'));
+    }
+}

--- a/force-app/main/default/classes/AdyenGatewayAdapterTest.cls-meta.xml
+++ b/force-app/main/default/classes/AdyenGatewayAdapterTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/AdyenPaymentHelper.cls
+++ b/force-app/main/default/classes/AdyenPaymentHelper.cls
@@ -107,7 +107,7 @@ public with sharing class AdyenPaymentHelper {
             notification = new CommercePayments.ReferencedRefundNotification();
             gatewayMessageTemplate = '[refund-{0}] {1}';
         } else {
-            throw new AdyenAsyncAdapter.GatewayException('Notification of type ' + notificationRequestItem.eventCode + ' does not match criteria');
+            throw new AdyenGatewayAdapter.GatewayException('Notification of type ' + notificationRequestItem.eventCode + ' does not match criteria');
         }
 
         String result;

--- a/force-app/main/default/classes/AdyenPaymentHelperTest.cls
+++ b/force-app/main/default/classes/AdyenPaymentHelperTest.cls
@@ -61,7 +61,7 @@ private class AdyenPaymentHelperTest {
             AdyenPaymentHelper.createNotificationSaveResult(nri);
             Assert.fail();
         } catch (Exception ex) { // then
-            Assert.isInstanceOfType(ex, AdyenAsyncAdapter.GatewayException.class);
+            Assert.isInstanceOfType(ex, AdyenGatewayAdapter.GatewayException.class);
         }
     }
 }

--- a/force-app/main/default/classes/AdyenPaymentUtility.cls
+++ b/force-app/main/default/classes/AdyenPaymentUtility.cls
@@ -27,7 +27,7 @@ public with sharing class AdyenPaymentUtility {
                 Id = :paymentId
         ];
         if (payments.isEmpty()) {
-            throw new AdyenAsyncAdapter.GatewayException(NO_PAYMENT_FOUND_BY_ID + paymentId);
+            throw new AdyenGatewayAdapter.GatewayException(NO_PAYMENT_FOUND_BY_ID + paymentId);
         }
         return payments[0];
     }
@@ -48,7 +48,7 @@ public with sharing class AdyenPaymentUtility {
             WHERE DeveloperName = :developerName
         ];
         if (adyenAdapters.isEmpty()) {
-            throw new AdyenAsyncAdapter.GatewayException(NO_ADYEN_ADAPTER_BY_NAME + developerName);
+            throw new AdyenGatewayAdapter.GatewayException(NO_ADYEN_ADAPTER_BY_NAME + developerName);
         }
         return adyenAdapters[0];
     }
@@ -63,7 +63,7 @@ public with sharing class AdyenPaymentUtility {
             WHERE Merchant_Account__c = :merchantAccountName
         ];
         if (adyenAdapters.isEmpty()) {
-            throw new AdyenAsyncAdapter.GatewayException(NO_ADYEN_ADAPTER_BY_MERCHANT + merchantAccountName);
+            throw new AdyenGatewayAdapter.GatewayException(NO_ADYEN_ADAPTER_BY_MERCHANT + merchantAccountName);
         }
         return adyenAdapters[0];
     }
@@ -109,7 +109,7 @@ public with sharing class AdyenPaymentUtility {
                 Id = :paymentAuthId
         ];
         if (paymentAuthorizations.isEmpty()) {
-            throw new AdyenAsyncAdapter.GatewayException(NO_PAYMENT_AUTH_FOUND_BY_ID + paymentAuthId);
+            throw new AdyenGatewayAdapter.GatewayException(NO_PAYMENT_AUTH_FOUND_BY_ID + paymentAuthId);
         }
         return paymentAuthorizations[0];
     }
@@ -383,7 +383,7 @@ public with sharing class AdyenPaymentUtility {
         CommercePayments.PaymentsHttp paymentsHttp = new CommercePayments.PaymentsHttp();
         HttpResponse response = paymentsHttp.send(request);
         if (response.getStatusCode() != 200 && response.getStatusCode() != 201) {
-            throw new AdyenAsyncAdapter.GatewayException('Adyen Checkout API returned: ' + response.getStatusCode() + ', body: ' + response.getBody());
+            throw new AdyenGatewayAdapter.GatewayException('Adyen Checkout API returned: ' + response.getStatusCode() + ', body: ' + response.getBody());
         } else {
             return response;
         }

--- a/force-app/main/default/classes/AdyenRefundHelper.cls
+++ b/force-app/main/default/classes/AdyenRefundHelper.cls
@@ -8,7 +8,6 @@ public with sharing class AdyenRefundHelper {
      * @param refundRequest   The CommercePayments.ReferencedRefundRequest Object.
      * @return refundResponse  The CommercePayments.ReferencedRefundResponse Object.
      *
-     * @see AdyenClient
     */
     public static CommercePayments.GatewayResponse refund(CommercePayments.ReferencedRefundRequest refundRequest) {
         Payment payment = AdyenPaymentUtility.retrievePayment(refundRequest.paymentId);
@@ -22,7 +21,7 @@ public with sharing class AdyenRefundHelper {
             errorMessage = 'Payment Amount Missing';
         }
         if (errorMessage != null) {
-            throw new AdyenAsyncAdapter.GatewayException(errorMessage);
+            throw new AdyenGatewayAdapter.GatewayException(errorMessage);
         }
 
         String pspReference = payment.PaymentAuthorization?.GatewayRefNumber != null ? payment.PaymentAuthorization.GatewayRefNumber : payment.GatewayRefNumber;

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -11,7 +11,7 @@ public class TestDataFactory {
     public static final String ACTIVE_CURRENCY = [SELECT IsoCode FROM CurrencyType WHERE IsActive = TRUE LIMIT 1].IsoCode;
     public static final String ASSERT_PRICE_MESSAGE = 'For input price of ';
 
-    public static AdyenAsyncAdapter adyenAdapter = new AdyenAsyncAdapter();
+    public static AdyenGatewayAdapter adyenAdapter = new AdyenGatewayAdapter();
 
     public static Account createAccount() {
         return new Account(Name = 'Test Account');

--- a/force-app/main/default/gatewayProviderPaymentMethodTypes/AlternativePaymentMethod.gatewayProviderPaymentMethodType-meta.xml
+++ b/force-app/main/default/gatewayProviderPaymentMethodTypes/AlternativePaymentMethod.gatewayProviderPaymentMethodType-meta.xml
@@ -2,7 +2,7 @@
 <GatewayProviderPaymentMethodType xmlns="http://soap.sforce.com/2006/04/metadata">
     <gtwyProviderPaymentMethodType>AdyenComponent</gtwyProviderPaymentMethodType>
     <masterLabel>Alternative Payment Method</masterLabel>
-    <paymentGatewayProvider>Adyen</paymentGatewayProvider>
+    <paymentGatewayProvider>Adyen_OMS_Provider</paymentGatewayProvider>
     <paymentMethodType>AlternativePaymentMethod</paymentMethodType>
     <recordType>AlternativePaymentMethod.Alternative_Payment_Method</recordType>
 </GatewayProviderPaymentMethodType>

--- a/force-app/main/default/paymentGatewayProviders/Adyen_OMS_Provider.paymentGatewayProvider-meta.xml
+++ b/force-app/main/default/paymentGatewayProviders/Adyen_OMS_Provider.paymentGatewayProvider-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PaymentGatewayProvider xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apexAdapter>AdyenAsyncAdapter</apexAdapter>
+    <apexAdapter>AdyenGatewayAdapter</apexAdapter>
     <idempotencySupported>Yes</idempotencySupported>
-    <masterLabel>SalesforceOrderManagement-Adyen</masterLabel>
+    <masterLabel>Adyen OMS Provider</masterLabel>
 </PaymentGatewayProvider>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -13,6 +13,8 @@
         <members>AdyenPaymentUtilityTest</members>
         <members>AdyenRefundHelper</members>
         <members>TestDataFactory</members>
+        <members>AdyenGatewayAdapter</members>
+        <members>AdyenGatewayAdapterTest</members>
         <name>ApexClass</name>
     </types>
     <types>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
We want to avoid conflict of gateway providers during upgrade
- What existing problem does this pull request solve?
Salesforce does not allow more than one gateway provider linked to the same class, so when upgrading the package the class has to be difference (since also it cannot be deleted). 