### PR TITLE
Populate Billing Address

### DIFF
--- a/force-app/main/default/classes/AdyenPBLHelper.cls
+++ b/force-app/main/default/classes/AdyenPBLHelper.cls
@@ -1,7 +1,7 @@
 public with sharing class AdyenPBLHelper {
     public static final List<String> ALLOWED_PAYMENT_METHODS = new List<String>{'ideal', 'scheme', 'paypal', 'applepay'};
 
-    public static PaymentLinkRequest buildPaymentLinkRequest(Adyen_Adapter__mdt adyenAdapter, Amount amount, String reference) {
+    public static PaymentLinkRequest buildPaymentLinkRequest(Adyen_Adapter__mdt adyenAdapter, Amount amount, String reference, Address adyenBillingAddress) {
         PaymentLinkRequest paymentLinkRequest = new PaymentLinkRequest();
         paymentLinkRequest.amount = amount;
         paymentLinkRequest.reference = reference;
@@ -10,6 +10,7 @@ public with sharing class AdyenPBLHelper {
         paymentLinkRequest.returnUrl = adyenAdapter.Payment_Link_Return_Url__c;
         paymentLinkRequest.themeId = adyenAdapter.Payment_Link_Theme_Id__c;
         paymentLinkRequest.allowedPaymentMethods = ALLOWED_PAYMENT_METHODS;
+        paymentLinkRequest.billingAddress = adyenBillingAddress;
         paymentLinkRequest.expiresAt = adyenAdapter.Payment_Link_Expiry_Duration__c != null 
             ? getLinkExpiryDate(adyenAdapter.Payment_Link_Expiry_Duration__c.intValue()) 
             : null;
@@ -92,6 +93,42 @@ public with sharing class AdyenPBLHelper {
         } else {
             String salesforceCompatibleBody = AdyenPaymentUtility.makeSalesforceCompatible(response.getBody());
             return salesforceCompatibleBody;
+        }
+    }
+
+    public static Address makeAdyenAddressCompatible(System.Address sfAddress) {
+        Address adyenAddress = new Address();
+        adyenAddress.city = sfAddress.city;
+        adyenAddress.country = sfAddress.country;
+        adyenAddress.postalCode = sfAddress.postalCode;
+        adyenAddress.stateOrProvince = sfAddress.state;
+        parseHouseNumberFromStreetAddress(sfAddress.street, adyenAddress);
+        return adyenAddress;
+    }
+
+    public static void parseHouseNumberFromStreetAddress(String streetAddressWithHouseNumber, Address adyenAddress) {
+        if (String.isBlank(streetAddressWithHouseNumber)) {
+            return;
+        }
+
+        // Regular expression to match numbers (house number) at the beginning or end of the address
+        Pattern numberPattern = Pattern.compile('^(\\d+)?\\s*(.*?)(\\d+)?$');
+        Matcher matcher = numberPattern.matcher(streetAddressWithHouseNumber.trim());
+
+        if (matcher.find()) {
+            // Check for house number at the start
+            if (matcher.group(1) != null) {
+                adyenAddress.houseNumberOrName = matcher.group(1).trim();
+                adyenAddress.street = matcher.group(2).trim();
+            }
+            // Check for house number at the end
+            else if (matcher.group(3) != null) {
+                adyenAddress.houseNumberOrName = matcher.group(3).trim();
+                adyenAddress.street = matcher.group(2).trim();
+            } else {
+                // If no number is found, treat the whole address as the street name
+                adyenAddress.street = streetAddressWithHouseNumber;
+            }
         }
     }
 }

--- a/force-app/main/default/classes/AdyenPBLHelperTest.cls
+++ b/force-app/main/default/classes/AdyenPBLHelperTest.cls
@@ -11,7 +11,7 @@ private class AdyenPBLHelperTest {
         String reference = 'TestReference123';
 
         // When
-        PaymentLinkRequest paymentLinkRequest = AdyenPBLHelper.buildPaymentLinkRequest(adyenAdapter, amount, reference);
+        PaymentLinkRequest paymentLinkRequest = AdyenPBLHelper.buildPaymentLinkRequest(adyenAdapter, amount, reference, Address.getExample());
 
         // Then
         Assert.areNotEqual(null, paymentLinkRequest);
@@ -31,7 +31,7 @@ private class AdyenPBLHelperTest {
         amount.value = 2000;
         String reference = 'TestReference456';
 
-        PaymentLinkRequest paymentLinkRequest = AdyenPBLHelper.buildPaymentLinkRequest(adyenAdapter, amount, reference);
+        PaymentLinkRequest paymentLinkRequest = AdyenPBLHelper.buildPaymentLinkRequest(adyenAdapter, amount, reference, Address.getExample());
 
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.PBLMockResponse());
 
@@ -68,7 +68,7 @@ private class AdyenPBLHelperTest {
         amount.value = 2000;
         String reference = 'TestReference789';
 
-        PaymentLinkRequest paymentLinkRequest = AdyenPBLHelper.buildPaymentLinkRequest(adyenAdapter, amount, reference);
+        PaymentLinkRequest paymentLinkRequest = AdyenPBLHelper.buildPaymentLinkRequest(adyenAdapter, amount, reference, Address.getExample());
 
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.FailureResponse());
 
@@ -97,6 +97,27 @@ private class AdyenPBLHelperTest {
     @IsTest
     static void makeAdyenAddressCompatibleTest() {
         // given - US address
-//        PaymentLinkGenerateAction.PBLCreateRequest
+        System.Address sfUSAddress = (System.Address)JSON.deserialize(TestDataFactory.US_JSON_ADDRESS, System.Address.class);
+        // when
+        Address adyenUSAddress = AdyenPBLHelper.makeAdyenAddressCompatible(sfUSAddress);
+        // then
+        Assert.areEqual('123', adyenUSAddress.houseNumberOrName);
+        Assert.areEqual('Market St', adyenUSAddress.street);
+
+        // given - Netherlands address
+        System.Address sfNLAddress = (System.Address)JSON.deserialize(TestDataFactory.NL_JSON_ADDRESS, System.Address.class);
+        // when
+        Address adyenNLAddress = AdyenPBLHelper.makeAdyenAddressCompatible(sfNLAddress);
+        // then
+        Assert.areEqual('1', adyenNLAddress.houseNumberOrName);
+        Assert.areEqual('Dam Square', adyenNLAddress.street);
+
+        // given - address without house number
+        System.Address sfNoNumberAddress = (System.Address)JSON.deserialize(TestDataFactory.NO_NUMBER_JSON_ADDRESS, System.Address.class);
+        // when
+        Address adyenNoNumberAddress = AdyenPBLHelper.makeAdyenAddressCompatible(sfNoNumberAddress);
+        // then
+        Assert.isNull(adyenNoNumberAddress.houseNumberOrName);
+        Assert.areEqual('Dam Square', adyenNoNumberAddress.street);
     }
 }

--- a/force-app/main/default/classes/AdyenPBLHelperTest.cls
+++ b/force-app/main/default/classes/AdyenPBLHelperTest.cls
@@ -93,4 +93,10 @@ private class AdyenPBLHelperTest {
         // Then
         Assert.isTrue(expiryDate.contains(expectedDate), 'Expiry date should contain the correct future date.');
     }
+
+    @IsTest
+    static void makeAdyenAddressCompatibleTest() {
+        // given - US address
+//        PaymentLinkGenerateAction.PBLCreateRequest
+    }
 }

--- a/force-app/main/default/classes/PaymentLinkGenerateAction.cls
+++ b/force-app/main/default/classes/PaymentLinkGenerateAction.cls
@@ -8,7 +8,9 @@ public with sharing class PaymentLinkGenerateAction {
         amount.value = (pblCreateRequest.amount * AdyenPaymentUtility.getAmountMultiplier(pblCreateRequest.currencyIsoCode)).round(System.RoundingMode.HALF_UP);
         amount.currency_x = pblCreateRequest.currencyIsoCode;
 
-        PaymentLinkRequest paymentLinkRequest = AdyenPBLHelper.buildPaymentLinkRequest(adyenAdapter, amount, pblCreateRequest.merchantReference);
+        System.Address sfBillingAddress = (System.Address)JSON.deserialize(pblCreateRequest.billingAddressJson, System.Address.class);
+        Address adyenBillingAddress = AdyenPBLHelper.makeAdyenAddressCompatible(sfBillingAddress);
+        PaymentLinkRequest paymentLinkRequest = AdyenPBLHelper.buildPaymentLinkRequest(adyenAdapter, amount, pblCreateRequest.merchantReference, adyenBillingAddress);
         PaymentLinkResponse paymentLinkResponse = AdyenPBLHelper.generatePaymentLink(adyenAdapter, paymentLinkRequest);
 
         PBLCreateResponse postAuthResponse = new PBLCreateResponse();
@@ -77,6 +79,9 @@ public with sharing class PaymentLinkGenerateAction {
 
         @InvocableVariable(Required=true)
         public String merchantReference;
+
+        @InvocableVariable(Required=true)
+        public String billingAddressJson;
     }
 
     public class PBLCreateResponse {

--- a/force-app/main/default/classes/PaymentLinkGenerateActionTest.cls
+++ b/force-app/main/default/classes/PaymentLinkGenerateActionTest.cls
@@ -11,6 +11,7 @@ private class PaymentLinkGenerateActionTest {
         postAuthRequest.accountId = testAccount.Id;
         postAuthRequest.currencyIsoCode = 'EUR';
         postAuthRequest.amount = 55.55;
+        postAuthRequest.billingAddressJson = TestDataFactory.NL_JSON_ADDRESS;
 
         List<PaymentLinkGenerateAction.PBLCreateRequest> postAuthRequests = new List<PaymentLinkGenerateAction.PBLCreateRequest>{ postAuthRequest };
         Test.startTest();

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -11,6 +11,10 @@ public class TestDataFactory {
     public static final Double TEST_TAX_AMOUNT = TEST_PRICE_AMOUNT * 0.05;
     public static final String ACTIVE_CURRENCY = [SELECT IsoCode FROM CurrencyType WHERE IsActive = TRUE LIMIT 1].IsoCode;
     public static final String ASSERT_PRICE_MESSAGE = 'For input price of ';
+    public static final String US_JSON_ADDRESS = '{"city": "San Francisco", "country": "USA", "postalCode": "94103", "state": "CA", "street": "123 Market St"}';
+    public static final String NL_JSON_ADDRESS = '{"city": "Amsterdam", "country": "Netherlands", "postalCode": "1012 JS", "state": "", "street": "Dam Square 1"}';
+    public static final String NO_NUMBER_JSON_ADDRESS = '{"city": "Amsterdam", "country": "Netherlands", "postalCode": "1012 JS", "state": "", "street": "Dam Square"}';
+
 
     public static AdyenGatewayAdapter adyenAdapter = new AdyenGatewayAdapter();
 

--- a/force-app/main/default/flows/Adyen_OOBO.flow-meta.xml
+++ b/force-app/main/default/flows/Adyen_OOBO.flow-meta.xml
@@ -116,7 +116,7 @@
         <name>Post_Authorize_Payment</name>
         <label>Post Authorize Payment</label>
         <locationX>2294</locationX>
-        <locationY>5762</locationY>
+        <locationY>5654</locationY>
         <actionName>PaymentLinkGenerateAction</actionName>
         <actionType>apex</actionType>
         <connector>
@@ -133,6 +133,12 @@
             <name>amount</name>
             <value>
                 <elementReference>cartSummaryTotals.grandTotalAmount</elementReference>
+            </value>
+        </inputParameters>
+        <inputParameters>
+            <name>billingAddressJson</name>
+            <value>
+                <elementReference>JSON_Address</elementReference>
             </value>
         </inputParameters>
         <inputParameters>
@@ -652,7 +658,7 @@
         <name>Current_Stage_Confirmation_Stage</name>
         <label>Current Stage = Confirmation</label>
         <locationX>2426</locationX>
-        <locationY>6278</locationY>
+        <locationY>6170</locationY>
         <assignmentItems>
             <assignToReference>$Flow.CurrentStage</assignToReference>
             <operator>Assign</operator>
@@ -723,7 +729,7 @@
         <name>Current_Stage_Submit_Order_Stage</name>
         <label>Current Stage = Submit Order</label>
         <locationX>2294</locationX>
-        <locationY>5978</locationY>
+        <locationY>5870</locationY>
         <assignmentItems>
             <assignToReference>$Flow.CurrentStage</assignToReference>
             <operator>Assign</operator>
@@ -1375,6 +1381,11 @@
         <valueField>Id</valueField>
     </dynamicChoiceSets>
     <environments>Default</environments>
+    <formulas>
+        <name>JSON_Address</name>
+        <dataType>String</dataType>
+        <expression>&apos;{&quot;city&quot;: &quot;&apos; &amp; {!Billing_Address.city} &amp; &apos;&quot;, &quot;country&quot;: &quot;&apos; &amp; {!Billing_Address.country} &amp; &apos;&quot;, &quot;postalCode&quot;: &quot;&apos; &amp; {!Billing_Address.postalCode} &amp; &apos;&quot;, &quot;state&quot;: &quot;&apos; &amp; {!Billing_Address.province} &amp; &apos;&quot;, &quot;street&quot;: &quot;&apos; &amp; {!Billing_Address.street} &amp; &apos;&quot;}&apos;</expression>
+    </formulas>
     <interviewLabel>Adyen OOBO {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Adyen OOBO</label>
     <loops>
@@ -1537,7 +1548,7 @@
         <name>Save_Payment_Link</name>
         <label>Save Payment Link</label>
         <locationX>2426</locationX>
-        <locationY>6386</locationY>
+        <locationY>6278</locationY>
         <connector>
             <targetReference>Confirmation_Screen</targetReference>
         </connector>
@@ -1648,7 +1659,7 @@
         <name>Get_Order_Reference</name>
         <label>Get Order Reference</label>
         <locationX>2294</locationX>
-        <locationY>5654</locationY>
+        <locationY>5546</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>Post_Authorize_Payment</targetReference>
@@ -1725,7 +1736,7 @@
         <locationY>5438</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
-            <targetReference>Billing_Details</targetReference>
+            <targetReference>Get_Order_Reference</targetReference>
         </connector>
         <filterLogic>and</filterLogic>
         <filters>
@@ -1752,7 +1763,7 @@
         <name>Update_Cart_Post_Auth</name>
         <label>Update Cart with Post Auth</label>
         <locationX>2294</locationX>
-        <locationY>5870</locationY>
+        <locationY>5762</locationY>
         <connector>
             <targetReference>Current_Stage_Submit_Order_Stage</targetReference>
         </connector>
@@ -1809,57 +1820,10 @@
         <object>WebCart</object>
     </recordUpdates>
     <screens>
-        <name>Billing_Details</name>
-        <label>Billing Details</label>
-        <locationX>2294</locationX>
-        <locationY>5546</locationY>
-        <allowBack>true</allowBack>
-        <allowFinish>true</allowFinish>
-        <allowPause>true</allowPause>
-        <connector>
-            <targetReference>Get_Order_Reference</targetReference>
-        </connector>
-        <fields>
-            <name>Billing_Informat_Title</name>
-            <fieldText>&lt;p style=&quot;text-align: center;&quot;&gt;&lt;strong&gt;Billing Information&lt;/strong&gt;&lt;/p&gt;</fieldText>
-            <fieldType>DisplayText</fieldType>
-        </fields>
-        <fields>
-            <name>Billing_Address</name>
-            <extensionName>flowruntime:address</extensionName>
-            <fieldType>ComponentInstance</fieldType>
-            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
-            <isRequired>true</isRequired>
-            <storeOutputAutomatically>true</storeOutputAutomatically>
-        </fields>
-        <fields>
-            <name>Payment_Details_footer</name>
-            <extensionName>runtime_commerce_oms:flowFooter</extensionName>
-            <fieldType>ComponentInstance</fieldType>
-            <inputParameters>
-                <name>currentStage</name>
-                <value>
-                    <elementReference>$Flow.CurrentStage</elementReference>
-                </value>
-            </inputParameters>
-            <inputParameters>
-                <name>stages</name>
-                <value>
-                    <elementReference>$Flow.ActiveStages</elementReference>
-                </value>
-            </inputParameters>
-            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
-            <isRequired>true</isRequired>
-            <storeOutputAutomatically>true</storeOutputAutomatically>
-        </fields>
-        <showFooter>false</showFooter>
-        <showHeader>true</showHeader>
-    </screens>
-    <screens>
         <name>Confirmation_Screen</name>
         <label>Confirmation Screen</label>
         <locationX>2426</locationX>
-        <locationY>6494</locationY>
+        <locationY>6386</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -1957,8 +1921,63 @@
             <targetReference>Update_Current_Stage_4</targetReference>
         </connector>
         <fields>
+            <name>Billing_Address_Text</name>
+            <fieldText>&lt;p style=&quot;text-align: center;&quot;&gt;&lt;span style=&quot;font-size: 20px; color: rgb(62, 62, 60);&quot;&gt;Enter Billing Address&lt;/span&gt;&lt;/p&gt;</fieldText>
+            <fieldType>DisplayText</fieldType>
+        </fields>
+        <fields>
+            <name>Billing_Address</name>
+            <extensionName>flowruntime:address</extensionName>
+            <fieldType>ComponentInstance</fieldType>
+            <inputParameters>
+                <name>addressLabel</name>
+                <value>
+                    <stringValue>Address</stringValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>required</name>
+                <value>
+                    <booleanValue>true</booleanValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>street</name>
+                <value>
+                    <elementReference>Get_Account.BillingStreet</elementReference>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>city</name>
+                <value>
+                    <elementReference>Get_Account.BillingCity</elementReference>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>province</name>
+                <value>
+                    <elementReference>Get_Account.BillingState</elementReference>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>postalCode</name>
+                <value>
+                    <elementReference>Get_Account.BillingPostalCode</elementReference>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>country</name>
+                <value>
+                    <elementReference>Get_Account.BillingCountry</elementReference>
+                </value>
+            </inputParameters>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
+            <isRequired>true</isRequired>
+            <storeOutputAutomatically>true</storeOutputAutomatically>
+        </fields>
+        <fields>
             <name>Header_enter_shipping_address</name>
-            <fieldText>&lt;p style=&quot;text-align: center;&quot;&gt;&lt;span style=&quot;color: rgb(62, 62, 60); font-size: 20px; background-color: rgb(255, 255, 255);&quot;&gt;Enter Shipping Address&lt;/span&gt;&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p style=&quot;text-align: center;&quot;&gt;&lt;span style=&quot;background-color: rgb(255, 255, 255); font-size: 20px; color: rgb(62, 62, 60);&quot;&gt;Enter Shipping Address&lt;/span&gt;&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <fields>
@@ -2058,7 +2077,7 @@
         <name>Payment_Screen</name>
         <label>Payment Screen</label>
         <locationX>2426</locationX>
-        <locationY>6170</locationY>
+        <locationY>6062</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>

--- a/force-app/main/default/flows/Regenerate_Payment_Link.flow-meta.xml
+++ b/force-app/main/default/flows/Regenerate_Payment_Link.flow-meta.xml
@@ -47,6 +47,12 @@
             </value>
         </inputParameters>
         <inputParameters>
+            <name>billingAddressJson</name>
+            <value>
+                <elementReference>Address_JSON</elementReference>
+            </value>
+        </inputParameters>
+        <inputParameters>
             <name>currencyIsoCode</name>
             <value>
                 <elementReference>Get_Last_Link.CurrencyIsoCode</elementReference>
@@ -66,6 +72,11 @@
     <apiVersion>62.0</apiVersion>
     <description>Flow used to deactivate any previous link and generate a new one.</description>
     <environments>Default</environments>
+    <formulas>
+        <name>Address_JSON</name>
+        <dataType>String</dataType>
+        <expression>&apos;{&quot;city&quot;: &quot;&apos; &amp; {!Get_Order_Summary.BillingCity} &amp; &apos;&quot;, &quot;country&quot;: &quot;&apos; &amp; {!Get_Order_Summary.BillingCountry} &amp; &apos;&quot;, &quot;postalCode&quot;: &quot;&apos; &amp; {!Get_Order_Summary.BillingPostalCode} &amp; &apos;&quot;, &quot;state&quot;: &quot;&apos; &amp; {!Get_Order_Summary.BillingState} &amp; &apos;&quot;, &quot;street&quot;: &quot;&apos; &amp; {!Get_Order_Summary.BillingStreet} &amp; &apos;&quot;}&apos;</expression>
+    </formulas>
     <interviewLabel>Regenerate Payment Link {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Regenerate Payment Link</label>
     <processMetadataValues>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -27,10 +27,9 @@
         <members>PaymentLinkExpireAction</members>
         <members>PaymentLinkExpireActionTest</members>
         <members>PaymentLinkGenerateAction</members>
-        <members>PaymentLinkPostAuthActionTest</members>
+        <members>PaymentLinkGenerateActionTest</members>
         <members>OrderSummaryCreatedEventHandler</members>
         <members>OrderSummaryCreatedEventHandlerTest</members>
-        <members>PaymentLinkGenerateActionTest</members>
         <name>ApexClass</name>
     </types>
     <types>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -27,7 +27,7 @@
         <members>PaymentLinkExpireAction</members>
         <members>PaymentLinkExpireActionTest</members>
         <members>PaymentLinkGenerateAction</members>
-        <members>PaymentLinkPostAuthActionTest</members>
+        <members>PaymentLinkGenerateActionTest</members>
         <name>ApexClass</name>
     </types>
     <types>
@@ -104,6 +104,9 @@
     <types>
         <members>Payment_Link__c</members>
         <name>CustomTab</name>
+    </types>
+    <types>
+        <name>WebLink</name>
     </types>
     <version>61.0</version>
 </Package>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
We are now pre-populating billing address in the PBL flow and sending in the request to Adyen
- What existing problem does this pull request solve?
This will enhance security validation for the merchant while having the billing address related to the order in SF
