### PR TITLE
Sync CA Capture and Refund with OMS

### DIFF
--- a/force-app/main/default/classes/AdyenOMSConstants.cls
+++ b/force-app/main/default/classes/AdyenOMSConstants.cls
@@ -25,12 +25,16 @@ public with sharing class AdyenOMSConstants {
     };
     public static final Set<String> VALID_WEBHOOK_TYPES = new Set<String>{
         AdyenConstants.NOTIFICATION_REQUEST_TYPE_AUTHORISE,
-        AdyenConstants.NOTIFICATION_REQUEST_TYPE_CANCEL
+        AdyenConstants.NOTIFICATION_REQUEST_TYPE_CANCEL,
+        AdyenConstants.NOTIFICATION_REQUEST_TYPE_CAPTURE,
+        AdyenConstants.NOTIFICATION_REQUEST_TYPE_REFUND
     };
 
     public static final Map<String,String> INTERACTION_TYPE_MAP = new Map<String,String>{
         AdyenConstants.NOTIFICATION_REQUEST_TYPE_CANCEL => 'AuthorizationReversal',
-        AdyenConstants.NOTIFICATION_REQUEST_TYPE_AUTHORISE => 'Authorization'
+        AdyenConstants.NOTIFICATION_REQUEST_TYPE_AUTHORISE => 'Authorization',
+        AdyenConstants.NOTIFICATION_REQUEST_TYPE_CAPTURE => 'Capture',
+        AdyenConstants.NOTIFICATION_REQUEST_TYPE_REFUND => 'ReferencedRefund'
     };
     public enum PaymentAuthorizationStatus { DRAFT, CANCELED, PENDING, PROCESSED, FAILED }
     public enum PaymentGatewayLogStatus { NOOP, INITIATED, SUCCESS, FAILED, TIMEOUT }

--- a/force-app/main/default/classes/NonPaymentWebhookHandler.cls
+++ b/force-app/main/default/classes/NonPaymentWebhookHandler.cls
@@ -19,11 +19,11 @@ global without sharing class NonPaymentWebhookHandler {
                 return responseWithReason(INVALID_WEBHOOK);
             }
             PaymentAuthorization paymentAuthorization = findPaymentAuthorization(notificationRequestItem);
-            if (paymentAuthorization == null) {
+            if (paymentAuthorization == null && !isValidRefund(notificationRequestItem)) {
                 return responseWithReason(NO_PAYMENT_FOUND);
             }
             processNotification(paymentAuthorization, notificationRequestItem);
-            if(requiresGatewayLog(notificationRequestItem)) {
+            if (requiresGatewayLog(notificationRequestItem)) {
                 createGatewayLog(paymentAuthorization, notificationRequestItem, requestBody);
             }
             return ACCEPTED_RESPONSE;
@@ -104,6 +104,13 @@ global without sharing class NonPaymentWebhookHandler {
             LIMIT 1
         ];
         return paymentAuthorizations.isEmpty() ? null : paymentAuthorizations[0];
+    }
+
+    private static Boolean isValidRefund(NotificationRequestItem requestItem) {
+        if (requestItem.eventCode != AdyenConstants.NOTIFICATION_REQUEST_TYPE_REFUND) {
+            return false;
+        }
+        return relatedPaymentFound(requestItem.originalReference);
     }
 
     private static Boolean relatedPaymentFound(String gatewayReference) {

--- a/force-app/main/default/classes/NonPaymentWebhookHandler.cls
+++ b/force-app/main/default/classes/NonPaymentWebhookHandler.cls
@@ -23,7 +23,9 @@ global without sharing class NonPaymentWebhookHandler {
                 return responseWithReason(NO_PAYMENT_FOUND);
             }
             processNotification(paymentAuthorization, notificationRequestItem);
-            createGatewayLog(paymentAuthorization, notificationRequestItem, requestBody);
+            if(requiresGatewayLog(notificationRequestItem)) {
+                createGatewayLog(paymentAuthorization, notificationRequestItem, requestBody);
+            }
             return ACCEPTED_RESPONSE;
         } catch (HMACValidator.HmacValidationException ex) {
             return responseWithReason(INVALID_NOTIFICATION);
@@ -102,5 +104,41 @@ global without sharing class NonPaymentWebhookHandler {
             LIMIT 1
         ];
         return paymentAuthorizations.isEmpty() ? null : paymentAuthorizations[0];
+    }
+
+    private static Boolean relatedPaymentFound(String gatewayReference) {
+        List<Payment> payments = [
+            SELECT Id
+            FROM Payment
+            WHERE GatewayRefNumber = :gatewayReference 
+            AND OrderPaymentSummaryId != NULL
+        ];
+        return !payments.isEmpty();
+    }
+
+    private static Boolean relatedRefundFound(String gatewayReference) {
+        List<Refund> refunds = [
+            SELECT Id
+            FROM Refund
+            WHERE GatewayRefNumber = :gatewayReference 
+            AND OrderPaymentSummaryId != NULL
+        ];
+        return !refunds.isEmpty();
+    }
+
+    private static Boolean requiresGatewayLog(NotificationRequestItem requestItem) {
+        if (requestItem.eventCode == AdyenConstants.NOTIFICATION_REQUEST_TYPE_AUTHORISE || 
+            requestItem.eventCode == AdyenConstants.NOTIFICATION_REQUEST_TYPE_CANCEL) {
+            return true;
+        }
+
+        if (requestItem.eventCode == AdyenConstants.NOTIFICATION_REQUEST_TYPE_CAPTURE) {
+            return !relatedPaymentFound(requestItem.pspReference);
+        }
+        if (requestItem.eventCode == AdyenConstants.NOTIFICATION_REQUEST_TYPE_REFUND) {
+            return !relatedRefundFound(requestItem.pspReference);
+        }
+    
+        return false;
     }
 }

--- a/force-app/main/default/classes/NonPaymentWebhookHandlerTest.cls
+++ b/force-app/main/default/classes/NonPaymentWebhookHandlerTest.cls
@@ -4,7 +4,7 @@ private class NonPaymentWebhookHandlerTest {
     @IsTest
     static void unsupportedNotificationTypeTest() {
         // given unsupported notification type (not a cancellation)
-        String wrongWebhookType = TestDataFactory.mockWebhookRequest(AdyenConstants.NOTIFICATION_REQUEST_TYPE_CAPTURE, '1234567890123456', '1010101010101010', '999999', true);
+        String wrongWebhookType = TestDataFactory.mockWebhookRequest(AdyenConstants.NOTIFICATION_REQUEST_TYPE_CAPTURE_FAILED, '1234567890123456', '1010101010101010', '999999', true);
         RestContext.request = createRestRequest(wrongWebhookType);
 
         // when
@@ -160,6 +160,44 @@ private class NonPaymentWebhookHandlerTest {
         Test.stopTest();
 
         Assert.areEqual(NonPaymentWebhookHandler.responseWithReason(NonPaymentWebhookHandler.NO_PAYMENT_FOUND), response);
+    }
+    
+    @IsTest(SeeAllData = true)
+    static void captureWebhookWithoutPaymentRecordTest() {
+        // given
+        PaymentAuthorization payAuth = TestDataFactory.insertAccountOrderAndPayAuth(AdyenOMSConstants.PaymentAuthorizationStatus.PROCESSED.name());
+        String captureWebhook = TestDataFactory.mockWebhookRequest(AdyenConstants.NOTIFICATION_REQUEST_TYPE_CAPTURE, '123456789012ABCD', TestDataFactory.TEST_PSP_REFERENCE, '999999', true);
+        RestContext.request = createRestRequest(captureWebhook);
+
+        // when
+        Test.startTest();
+        String response = NonPaymentWebhookHandler.doPost();
+        Test.stopTest();
+
+        // then
+        PaymentGatewayLog captureGatewayLog = [SELECT Id, GatewayRefNumber, GatewayMessage, InteractionStatus FROM PaymentGatewayLog WHERE GatewayRefNumber = '123456789012ABCD' LIMIT 1];
+        Assert.areEqual(NonPaymentWebhookHandler.ACCEPTED_RESPONSE, response, 'Expected accepted response');
+        Assert.areEqual('Success', captureGatewayLog.InteractionStatus, 'Expected interaction status to be Success.');
+        Assert.areEqual('[capture-completed]', captureGatewayLog.GatewayMessage);
+    }
+    
+    @IsTest(SeeAllData = true)
+    static void refundWebhookWithoutRefundRecordTest() {
+        // given
+        PaymentAuthorization payAuth = TestDataFactory.insertAccountOrderAndPayAuth(AdyenOMSConstants.PaymentAuthorizationStatus.PROCESSED.name());
+        String refundWebhook = TestDataFactory.mockWebhookRequest(AdyenConstants.NOTIFICATION_REQUEST_TYPE_REFUND, '123456789012ABCD', TestDataFactory.TEST_PSP_REFERENCE, '999999', true);
+        RestContext.request = createRestRequest(refundWebhook);
+
+        // when
+        Test.startTest();
+        String response = NonPaymentWebhookHandler.doPost();
+        Test.stopTest();
+
+        // then
+        PaymentGatewayLog refundGatewayLog = [SELECT Id, GatewayRefNumber, GatewayMessage, InteractionStatus FROM PaymentGatewayLog WHERE GatewayRefNumber = '123456789012ABCD' LIMIT 1];
+        Assert.areEqual(NonPaymentWebhookHandler.ACCEPTED_RESPONSE, response, 'Expected accepted response');
+        Assert.areEqual('Success', refundGatewayLog.InteractionStatus, 'Expected interaction status to be Success.');
+        Assert.areEqual('[refund-completed]', refundGatewayLog.GatewayMessage);
     }
 
     private static RestRequest createRestRequest(String body) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Currently, captures and refunds initiated from CA are not reflected in OMS.
- What existing problem does this pull request solve?
Creating a gateway log in OMS when captures or refunds are completed from CA. This will provide better visibility for merchants.

