### PR TITLE
Check payment method in payment record as fallback

### DIFF
--- a/force-app/main/default/classes/AdyenOMSConstants.cls
+++ b/force-app/main/default/classes/AdyenOMSConstants.cls
@@ -15,7 +15,7 @@ public with sharing class AdyenOMSConstants {
     public static final String CARD_PAYMENT_METHOD_OBJECT = 'CardPaymentMethod';
     public static final String ALTERNATIVE_PAYMENT_METHOD_OBJECT = 'AlternativePaymentMethod';
 
-    public static final Set<String> OPEN_INVOICE_METHODS = new Set<String>{'klarna', 'afterpay', 'ratepay', 'facilypay', 'zip', 'affirm', 'atome', 'walley', 'clearpay'};
+    public static final Set<String> OPEN_INVOICE_METHODS = new Set<String>{'klarna', 'afterpay', 'ratepay', 'facilypay', 'zip', 'affirm', 'atome', 'walley', 'clearpay', 'riverty'};
 
     public static final Set<String> VALID_NOTIFICATION_TYPES = new Set<String>{
         AdyenConstants.NOTIFICATION_REQUEST_TYPE_CAPTURE,

--- a/force-app/main/default/classes/AdyenPaymentUtility.cls
+++ b/force-app/main/default/classes/AdyenPaymentUtility.cls
@@ -19,7 +19,7 @@ public with sharing class AdyenPaymentUtility {
     public static Payment retrievePayment(Id paymentId) {
         List<Payment> payments = [
             SELECT
-                Id, GatewayRefNumber, GatewayRefDetails,
+                Id, GatewayRefNumber, GatewayRefDetails, Adyen_Payment_Method_Variant__c,
                 PaymentAuthorization.GatewayRefNumber, PaymentAuthorization.Adyen_Payment_Method_Variant__c,
                 PaymentAuthorization.Adyen_Payment_Method__c,CurrencyIsoCode, OrderPaymentSummary.FullName,
                 OrderPaymentSummary.OrderSummary.SalesChannel.AdyenMerchantID__c
@@ -134,11 +134,26 @@ public with sharing class AdyenPaymentUtility {
     * @return Boolean denoting if the Authorization Id belongs to an Open Invoice payment method.
     */
     public static Boolean checkIfOpenInvoiceFromAuthorization(PaymentAuthorization pa) {
-        if (pa != null && pa.Adyen_Payment_Method_Variant__c != null) {
+        return isOpenInvoicePaymentMethod(pa?.Adyen_Payment_Method_Variant__c);
+    }
+
+    public static Boolean isOpenInvoicePayment(Payment payment) {
+        if (checkIfOpenInvoiceFromAuthorization(payment.PaymentAuthorization)) {
+            return true;
+        }
+        return checkIfOpenInvoiceFromPayment(payment);
+    }
+
+    public static Boolean checkIfOpenInvoiceFromPayment(Payment payment) {
+        return isOpenInvoicePaymentMethod(payment?.Adyen_Payment_Method_Variant__c);
+    }
+
+    private static Boolean isOpenInvoicePaymentMethod(String paymentMethodVariant) {
+        if (paymentMethodVariant != null) {
             for (String openInvoiceMethod : AdyenOMSConstants.OPEN_INVOICE_METHODS) {
-                 if (pa.Adyen_Payment_Method_Variant__c.containsIgnoreCase(openInvoiceMethod)) {
-                     return true;
-                 }
+                if (paymentMethodVariant.containsIgnoreCase(openInvoiceMethod)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/force-app/main/default/classes/AdyenPaymentUtilityTest.cls
+++ b/force-app/main/default/classes/AdyenPaymentUtilityTest.cls
@@ -193,6 +193,24 @@ private class AdyenPaymentUtilityTest {
             Assert.areEqual(ex.getMessage(), AdyenPaymentUtility.NO_ORDER_PAY_SUM_FOUND_BY_ID + acct.Id);
         }
     }
+    
+    @IsTest
+    static void checkIfOpenInvoiceWithoutPayAuthTest() {
+        // given
+        Account acct = TestDataFactory.createAccount();
+        insert acct;
+        CardPaymentMethod paymentMethod = TestDataFactory.createCardPaymentMethod();
+        insert paymentMethod;
+       	Payment payment = TestDataFactory.createPayment(acct.Id, paymentMethod.Id, null, null, null);
+        payment.Adyen_Payment_Method_Variant__c = 'klarna_paynow';
+        insert payment;
+        
+        // when
+        Boolean isOpenInvoice = AdyenPaymentUtility.isOpenInvoicePayment(payment);
+        
+        // then
+        Assert.isTrue(isOpenInvoice);
+    }
 
     private static OrderPaymentSummary createInvoiceAndRelatedRecords(Decimal price, Decimal taxValue) {
         Account acct = TestDataFactory.createAccount();

--- a/force-app/main/default/classes/AdyenRefundHelper.cls
+++ b/force-app/main/default/classes/AdyenRefundHelper.cls
@@ -37,7 +37,7 @@ public with sharing class AdyenRefundHelper {
     private static CheckoutRefundRequest createRefundRequest(CommercePayments.ReferencedRefundRequest refundRequest, Payment payment, Adyen_Adapter__mdt adyenAdapter) {
         CheckoutRefundRequest modRequest = (CheckoutRefundRequest)AdyenPaymentUtility.createModificationRequest(refundRequest, payment.CurrencyIsoCode, adyenAdapter);
         //Only for Paypal Refunds - Capture reference must be a substring of refund reference
-        if (String.isNotBlank(payment.PaymentAuthorization.Adyen_Payment_Method_Variant__c)) {
+        if (String.isNotBlank(payment.PaymentAuthorization?.Adyen_Payment_Method_Variant__c)) {
             if (payment.PaymentAuthorization.Adyen_Payment_Method_Variant__c.equalsIgnoreCase('Paypal') && String.isNotBlank(payment.GatewayRefDetails)) {
                 String refundReference = modRequest.getReference() + payment.GatewayRefDetails;
                 modRequest.setReference(refundReference);
@@ -45,7 +45,7 @@ public with sharing class AdyenRefundHelper {
             }
         }
         // Line items required for partial refunds for Open Invoice methods
-        if (AdyenPaymentUtility.checkIfOpenInvoiceFromAuthorization(payment.PaymentAuthorization)) {
+        if (AdyenPaymentUtility.isOpenInvoicePayment(payment)) {
             modRequest.setLineItems(AdyenPaymentUtility.addCreditMemoData(payment.OrderPaymentSummary.OrderSummaryId));
         }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
When determining the payment method for refund logic, only the payment authorization is analyzed, excluding line items in the Sales flow.
- What existing problem does this pull request solve?
- Added fallback to check the payment record when no payment authorization is found.

