### PR TITLE
Return error response for failed HMAC validation

### DIFF
--- a/force-app/main/default/classes/AdyenNotificationHandler.cls
+++ b/force-app/main/default/classes/AdyenNotificationHandler.cls
@@ -11,10 +11,10 @@ public with sharing class AdyenNotificationHandler {
         try {
             validator = new HMACValidator(notificationRequestItem, adyenAdapter.HMAC_Key__c);
             if (!Test.isRunningTest() && !validator.validateHMAC()) {
-                return createAcceptedNotificationResponse('not a valid notification request');
+                return createErrorResponse(AdyenOMSConstants.INVALID_NOTIFICATION, 403);
             }
         } catch (HMACValidator.HmacValidationException hmacValidationException) {
-            return createAcceptedNotificationResponse(hmacValidationException.getMessage());
+            return createErrorResponse(hmacValidationException.getMessage(), 403);
         }
 
         if (!AdyenPaymentUtility.isValidNotification(notificationRequestItem)) {
@@ -38,6 +38,13 @@ public with sharing class AdyenNotificationHandler {
         CommercePayments.GatewayNotificationResponse gatewayNotificationResponse = new CommercePayments.GatewayNotificationResponse();
         gatewayNotificationResponse.setResponseBody(Blob.valueOf(responseMessage));
         gatewayNotificationResponse.setStatusCode(AdyenConstants.HTTP_SUCCESS_CODE);
+        return gatewayNotificationResponse;
+    }
+
+    private static CommercePayments.GatewayNotificationResponse createErrorResponse(String message, Integer statusCode) {
+        CommercePayments.GatewayNotificationResponse gatewayNotificationResponse = new CommercePayments.GatewayNotificationResponse();
+        gatewayNotificationResponse.setResponseBody(Blob.valueOf(message));
+        gatewayNotificationResponse.setStatusCode(statusCode);
         return gatewayNotificationResponse;
     }
 

--- a/force-app/main/default/classes/AdyenOMSConstants.cls
+++ b/force-app/main/default/classes/AdyenOMSConstants.cls
@@ -47,4 +47,5 @@ public with sharing class AdyenOMSConstants {
     public static final String PBL_ID_KEY = 'pblId';
     public static final String GATEWAY_RESULT_SUCCESS = 'success';
     public static final String GATEWAY_RESULT_SUCCESS_DESCRIPTION = 'Transaction Normal';
+    public static final String INVALID_NOTIFICATION = 'Not a valid notification request';
 }

--- a/force-app/main/default/classes/NonPaymentWebhookHandler.cls
+++ b/force-app/main/default/classes/NonPaymentWebhookHandler.cls
@@ -1,7 +1,6 @@
 @RestResource(UrlMapping='/nonPaymentWebhook/v1/*')
 global without sharing class NonPaymentWebhookHandler {
     public static final String ACCEPTED_RESPONSE = '[accepted]';
-    public static final String INVALID_NOTIFICATION = 'but not a valid notification request';
     public static final String INVALID_WEBHOOK = 'but no valid psp reference found or webhook type was ignored';
     public static final String NO_PAYMENT_FOUND = 'but no related payment record found';
     public static final String EXCEPTION_OCCURRED = 'but an exception happened: ';
@@ -13,7 +12,7 @@ global without sharing class NonPaymentWebhookHandler {
             NotificationRequestItem notificationRequestItem = WebhookUtils.parseAdyenNotificationRequest(requestBody);
             Adyen_Adapter__mdt adyenAdapter = AdyenPaymentUtility.retrieveAdapterByMerchantAcct(notificationRequestItem.merchantAccountCode);
             if (!isValidRequest(notificationRequestItem, adyenAdapter)) {
-                return responseWithReason(INVALID_NOTIFICATION);
+                return createErrorResponse(AdyenOMSConstants.INVALID_NOTIFICATION, 403);
             }
             if (!AdyenPaymentUtility.isValidNonPaymentWebhook(notificationRequestItem)) {
                 return responseWithReason(INVALID_WEBHOOK);
@@ -28,7 +27,7 @@ global without sharing class NonPaymentWebhookHandler {
             }
             return ACCEPTED_RESPONSE;
         } catch (HMACValidator.HmacValidationException ex) {
-            return responseWithReason(INVALID_NOTIFICATION);
+            return createErrorResponse(ex.getMessage(), 403);
         } catch (Exception ex) {
             return responseWithReason(EXCEPTION_OCCURRED + ex.getMessage());
         }
@@ -42,6 +41,11 @@ global without sharing class NonPaymentWebhookHandler {
     @TestVisible
     private static String responseWithReason(String reason) {
         return ACCEPTED_RESPONSE + ', ' + reason;
+    }
+    
+    private static String createErrorResponse(String reason, Integer statusCode) {
+        RestContext.response.statusCode = statusCode;
+        return reason;
     }
 
     private static void createGatewayLog(PaymentAuthorization paymentAuthorization, NotificationRequestItem notificationRequestItem, String requestBody) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
What is the motivation for this change?
The error status code was not being set when HMAC validation failed for the webhook.
What existing problem does this pull request solve?
It returns a 403 status code when HMAC validation fails during webhook processing.
