### PR TITLE
Execute SFCC custom job for OMS E2E test workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,4 +92,7 @@ jobs:
           SFCC_HOSTNAME: ${{ secrets.SFCC_HOSTNAME }}
           SFCC_STOREFRONT_USERNAME: ${{ secrets.SFCC_STOREFRONT_USERNAME }}
           SFCC_STOREFRONT_PASSWORD: ${{ secrets.SFCC_STOREFRONT_PASSWORD }}
+          SFCC_CLIENT_ID: ${{ secrets.SFCC_CLIENT_ID }}
+          SFCC_CLIENT_SECRET: ${{ secrets.SFCC_CLIENT_SECRET }}
+          SFCC_JOB_WAIT_TIME: ${{ secrets.SFCC_JOB_WAIT_TIME }}
           MAX_POLL_ATTEMPTS: ${{ vars.MAX_POLL_ATTEMPTS }}

--- a/e2e/__tests__/creditCard.spec.mjs
+++ b/e2e/__tests__/creditCard.spec.mjs
@@ -8,6 +8,7 @@ import { CardData } from '../playwright/data/cardData.mjs';
 const shopperData = new ShopperData();
 const cardData = new CardData();
 const maxPollAttempts = process.env.MAX_POLL_ATTEMPTS;
+const jobWaitTime = parseInt(process.env.SFCC_JOB_WAIT_TIME, 10) || 90000;
 let sfConnection;
 let checkoutPage;
 let cards;
@@ -48,9 +49,39 @@ test.describe('E2E Order Creation and Payment Capture', () => {
     const orderNumberElementContent = await orderNumberElement.textContent();
 
     orderNumber = orderNumberElementContent.trim();
-
     await browser.close();
-  }, 90000);
+
+    await new Promise(resolve => setTimeout(resolve, jobWaitTime));
+
+    const tokenResponse = await fetch(
+      `https://account.demandware.com/dw/oauth2/access_token`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Basic ' + Buffer.from(`${process.env.SFCC_CLIENT_ID}:${process.env.SFCC_CLIENT_SECRET}`).toString('base64'),
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: 'grant_type=client_credentials',
+      }
+    );
+    if (!tokenResponse.ok) throw new Error(`Token request failed`);
+    const tokenData = await tokenResponse.json();
+    const accessToken = tokenData.access_token;
+
+    const jobResponse = await fetch(
+      `https://${process.env.SFCC_HOSTNAME}/s/-/dw/data/v24_5/jobs/Process/executions`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: '{}',
+      }
+    );
+    if (!jobResponse.ok) throw new Error(`Job execution failed with status: ${jobResponse.status}`);
+  
+  }, 90000 + jobWaitTime);
 
   test('should create a fulfillment order, invoice, and capture payment', async () => {
     const orderSummaryRecords = await pollOrderSummary(orderNumber, maxPollAttempts);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Currently, in the OMS E2E workflow, orders placed in SFCC don’t automatically flow to OMS because the custom job isn’t triggered.
- What existing problem does this pull request solve?
This PR adds execution of the custom job to the E2E test to trigger the order flow to  OMS.



