### PR TITLE
Populate Merchant Reference on Refund Records

### DIFF
--- a/force-app/main/default/classes/AdyenRefundRefBatchJobScheduler.cls
+++ b/force-app/main/default/classes/AdyenRefundRefBatchJobScheduler.cls
@@ -1,0 +1,6 @@
+global with sharing class AdyenRefundRefBatchJobScheduler implements Schedulable{
+    global void execute(SchedulableContext schedulableContext) {
+        AdyenRefundReferenceBatch batch = new AdyenRefundReferenceBatch();
+        Database.executeBatch(batch); 
+    }
+}

--- a/force-app/main/default/classes/AdyenRefundRefBatchJobScheduler.cls-meta.xml
+++ b/force-app/main/default/classes/AdyenRefundRefBatchJobScheduler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/AdyenRefundRefBatchJobSchedulerTest.cls
+++ b/force-app/main/default/classes/AdyenRefundRefBatchJobSchedulerTest.cls
@@ -1,0 +1,19 @@
+@IsTest
+private class AdyenRefundRefBatchJobSchedulerTest {
+    
+    @IsTest
+    static void scheduleJobTest() {
+        // Given
+        AdyenRefundRefBatchJobScheduler scheduler = new AdyenRefundRefBatchJobScheduler();
+        String cronExp = '0 0 * * * ?';
+        
+        // When
+        Test.startTest();
+        String jobId = System.schedule('Test Refund Reference Batch', cronExp, scheduler);
+        Test.stopTest();
+        
+        // Then
+        CronTrigger ct = [SELECT Id, CronExpression FROM CronTrigger WHERE Id = :jobId];
+        Assert.areEqual(cronExp, ct.CronExpression, 'Expected cron expression to match');
+    }
+}

--- a/force-app/main/default/classes/AdyenRefundRefBatchJobSchedulerTest.cls-meta.xml
+++ b/force-app/main/default/classes/AdyenRefundRefBatchJobSchedulerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/AdyenRefundReferenceBatch.cls
+++ b/force-app/main/default/classes/AdyenRefundReferenceBatch.cls
@@ -17,34 +17,32 @@ public with sharing class AdyenRefundReferenceBatch implements Database.Batchabl
     
     public void execute(Database.BatchableContext batchContext, List<PaymentGatewayLog> gatewayLogs) {
         try {
-            
-            Map<Id, String> refundIdToReferenceMap = new Map<Id, String>();
-    
+            Map<Id, Refund> refundsToUpdate = new Map<Id, Refund>();
+
             for (PaymentGatewayLog gatewayLog : gatewayLogs) {
                 if (gatewayLog.Request != null && gatewayLog.ReferencedEntityId != null) {
                     Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(gatewayLog.Request);
                     String reference = (String) jsonMap.get('reference');
                     if (String.isNotBlank(reference)) {
-                        refundIdToReferenceMap.put(gatewayLog.ReferencedEntityId, reference);
+                        refundsToUpdate.put(
+                            gatewayLog.ReferencedEntityId,
+                            new Refund(
+                                Id = gatewayLog.ReferencedEntityId,
+                                Refund_Reference__c = reference
+                            )
+                        );
                     }
                 }
             }
-            
-            if (!refundIdToReferenceMap.isEmpty()) {
-                List<Refund> refundsToUpdate = new List<Refund>();
-                for (Id refundId : refundIdToReferenceMap.keySet()) {
-                    refundsToUpdate.add(new Refund(
-                        Id = refundId,
-                        Refund_Reference__c = refundIdToReferenceMap.get(refundId)
-                    ));
-                }
-                update refundsToUpdate;
+
+            if (!refundsToUpdate.isEmpty()) {
+                update refundsToUpdate.values();
             }
         } catch (Exception e) {
-            System.debug('Exception occured during batch execution: ' + e.getMessage());
+            System.debug('Exception occurred during batch execution: ' + e.getMessage());
         }
     }
-    
+
     public void finish(Database.BatchableContext batchContext) {
         // No additional logic needed after batch execution
     }

--- a/force-app/main/default/classes/AdyenRefundReferenceBatch.cls
+++ b/force-app/main/default/classes/AdyenRefundReferenceBatch.cls
@@ -22,7 +22,7 @@ public with sharing class AdyenRefundReferenceBatch implements Database.Batchabl
             if (gatewayLog.Request != null && gatewayLog.ReferencedEntityId != null) {
                 Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(gatewayLog.Request);
                 String reference = (String) jsonMap.get('reference');
-                if (reference != null) {
+                if (String.isNotBlank(reference)) {
                     refundIdToReferenceMap.put(gatewayLog.ReferencedEntityId, reference);
                 }
             }

--- a/force-app/main/default/classes/AdyenRefundReferenceBatch.cls
+++ b/force-app/main/default/classes/AdyenRefundReferenceBatch.cls
@@ -1,0 +1,46 @@
+public with sharing class AdyenRefundReferenceBatch implements Database.Batchable<sObject> {
+         
+    public Database.QueryLocator start(Database.BatchableContext batchContext) {
+        return Database.getQueryLocator([
+            SELECT Id, Request, ReferencedEntityId
+            FROM PaymentGatewayLog
+            WHERE InteractionType = 'ReferencedRefund'
+            AND GatewayMessage = '[refund-received]'
+            AND ReferencedEntityId != NULL
+            AND ReferencedEntityId IN (
+                SELECT Id
+                FROM Refund
+                WHERE Refund_Reference__c = NULL
+            )
+        ]);
+    }
+    
+    public void execute(Database.BatchableContext batchContext, List<PaymentGatewayLog> gatewayLogs) {
+        Map<Id, String> refundIdToReferenceMap = new Map<Id, String>();
+        
+        for (PaymentGatewayLog gatewayLog : gatewayLogs) {
+            if (gatewayLog.Request != null && gatewayLog.ReferencedEntityId != null) {
+                Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(gatewayLog.Request);
+                String reference = (String) jsonMap.get('reference');
+                if (reference != null) {
+                    refundIdToReferenceMap.put(gatewayLog.ReferencedEntityId, reference);
+                }
+            }
+        }
+        
+        if (!refundIdToReferenceMap.isEmpty()) {
+            List<Refund> refundsToUpdate = new List<Refund>();
+            for (Id refundId : refundIdToReferenceMap.keySet()) {
+                refundsToUpdate.add(new Refund(
+                    Id = refundId,
+                    Refund_Reference__c = refundIdToReferenceMap.get(refundId)
+                ));
+            }
+            update refundsToUpdate;
+        }
+    }
+    
+    public void finish(Database.BatchableContext batchContext) {
+        // No additional logic needed after batch execution
+    }
+}

--- a/force-app/main/default/classes/AdyenRefundReferenceBatch.cls
+++ b/force-app/main/default/classes/AdyenRefundReferenceBatch.cls
@@ -16,27 +16,32 @@ public with sharing class AdyenRefundReferenceBatch implements Database.Batchabl
     }
     
     public void execute(Database.BatchableContext batchContext, List<PaymentGatewayLog> gatewayLogs) {
-        Map<Id, String> refundIdToReferenceMap = new Map<Id, String>();
-        
-        for (PaymentGatewayLog gatewayLog : gatewayLogs) {
-            if (gatewayLog.Request != null && gatewayLog.ReferencedEntityId != null) {
-                Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(gatewayLog.Request);
-                String reference = (String) jsonMap.get('reference');
-                if (String.isNotBlank(reference)) {
-                    refundIdToReferenceMap.put(gatewayLog.ReferencedEntityId, reference);
+        try {
+            
+            Map<Id, String> refundIdToReferenceMap = new Map<Id, String>();
+    
+            for (PaymentGatewayLog gatewayLog : gatewayLogs) {
+                if (gatewayLog.Request != null && gatewayLog.ReferencedEntityId != null) {
+                    Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(gatewayLog.Request);
+                    String reference = (String) jsonMap.get('reference');
+                    if (String.isNotBlank(reference)) {
+                        refundIdToReferenceMap.put(gatewayLog.ReferencedEntityId, reference);
+                    }
                 }
             }
-        }
-        
-        if (!refundIdToReferenceMap.isEmpty()) {
-            List<Refund> refundsToUpdate = new List<Refund>();
-            for (Id refundId : refundIdToReferenceMap.keySet()) {
-                refundsToUpdate.add(new Refund(
-                    Id = refundId,
-                    Refund_Reference__c = refundIdToReferenceMap.get(refundId)
-                ));
+            
+            if (!refundIdToReferenceMap.isEmpty()) {
+                List<Refund> refundsToUpdate = new List<Refund>();
+                for (Id refundId : refundIdToReferenceMap.keySet()) {
+                    refundsToUpdate.add(new Refund(
+                        Id = refundId,
+                        Refund_Reference__c = refundIdToReferenceMap.get(refundId)
+                    ));
+                }
+                update refundsToUpdate;
             }
-            update refundsToUpdate;
+        } catch (Exception e) {
+            System.debug('Exception occured during batch execution: ' + e.getMessage());
         }
     }
     

--- a/force-app/main/default/classes/AdyenRefundReferenceBatch.cls-meta.xml
+++ b/force-app/main/default/classes/AdyenRefundReferenceBatch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/AdyenRefundReferenceBatchTest.cls
+++ b/force-app/main/default/classes/AdyenRefundReferenceBatchTest.cls
@@ -1,0 +1,121 @@
+@IsTest
+private class AdyenRefundReferenceBatchTest {
+    
+    @TestSetup
+    static void setupTestData() {
+        Refund refund = new Refund(
+            Status = 'Processed',
+            Type = 'Referenced',
+            ProcessingMode = 'External',
+            Amount = 100.00
+        );
+        insert refund;
+        
+        Refund refundWithReference = new Refund(
+            Status = 'Processed',
+            Type = 'Referenced',
+            ProcessingMode = 'External',
+            Amount = 100.00,
+            Refund_Reference__c = '12345'
+        );
+        insert refundWithReference;
+    }
+    
+    @IsTest
+    static void validReferenceTest() {
+        // Given
+        Refund refund = [SELECT Id FROM Refund WHERE Refund_Reference__c = NULL LIMIT 1];
+        
+        PaymentGatewayLog gatewayLog = new PaymentGatewayLog(
+            InteractionType = 'ReferencedRefund',
+            GatewayMessage = '[refund-received]',
+            ReferencedEntityId = refund.Id,
+            Request = '{"reference":"0000000292873000"}'
+        );
+        insert gatewayLog;
+        
+        // When
+        AdyenRefundReferenceBatch batch = new AdyenRefundReferenceBatch();
+        Test.startTest();
+        Database.executeBatch(batch);
+        Test.stopTest();
+        
+        // Then
+        Refund updatedRefund = [SELECT Id, Refund_Reference__c FROM Refund WHERE Id = :refund.Id];
+        Assert.areEqual('0000000292873000', updatedRefund.Refund_Reference__c, 
+                        'Expected Refund_Reference__c to be updated with the reference 0000000292873000');
+    }
+    
+    @IsTest
+    static void missingReferenceTest() {
+        // Given
+        Refund refund = [SELECT Id FROM Refund WHERE Refund_Reference__c = NULL LIMIT 1];
+        
+        List<PaymentGatewayLog> gatewayLogs = new List<PaymentGatewayLog>();
+        gatewayLogs.add(new PaymentGatewayLog(
+            InteractionType = 'ReferencedRefund',
+            GatewayMessage = '[refund-received]',
+            ReferencedEntityId = refund.Id,
+            Request = '{"merchantAccount":"Test_Merchant_Account"}'
+        ));
+        insert gatewayLogs;
+        
+        // When
+        AdyenRefundReferenceBatch batch = new AdyenRefundReferenceBatch();
+        Test.startTest();
+        Database.executeBatch(batch);
+        Test.stopTest();
+        
+        // Then
+        Refund updatedRefund = [SELECT Id, Refund_Reference__c FROM Refund WHERE Id = :refund.Id];
+        Assert.isNull(updatedRefund.Refund_Reference__c, 'Expected Refund_Reference__c to remain null');
+    }
+    
+    @IsTest
+    static void nullRequestTest() {
+        // Given
+        Refund refund = [SELECT Id FROM Refund WHERE Refund_Reference__c = NULL LIMIT 1];
+        
+        PaymentGatewayLog gatewayLog = new PaymentGatewayLog(
+            InteractionType = 'ReferencedRefund',
+            GatewayMessage = '[refund-received]',
+            ReferencedEntityId = refund.Id,
+            Request = null
+        );
+        insert gatewayLog;
+        
+        // When
+        AdyenRefundReferenceBatch batch = new AdyenRefundReferenceBatch();
+        Test.startTest();
+        Database.executeBatch(batch);
+        Test.stopTest();
+        
+        // Then
+        Refund updatedRefund = [SELECT Id, Refund_Reference__c FROM Refund WHERE Id = :refund.Id];
+        Assert.isNull(updatedRefund.Refund_Reference__c, 'Expected Refund_Reference__c to remain null');
+    }
+    
+    @IsTest
+    static void noEligibleRecordsTest() {
+        // Given
+        Refund refund = [SELECT Id FROM Refund WHERE Refund_Reference__c = '12345' LIMIT 1];
+        
+        PaymentGatewayLog gatewayLog = new PaymentGatewayLog(
+            InteractionType = 'ReferencedRefund',
+            GatewayMessage = '[refund-received]',
+            ReferencedEntityId = refund.Id,
+            Request = '{"reference":"0000000292873000"}'
+        );
+        insert gatewayLog;
+        
+        // When
+        AdyenRefundReferenceBatch batch = new AdyenRefundReferenceBatch();
+        Test.startTest();
+        Database.executeBatch(batch);
+        Test.stopTest();
+        
+        // Then
+        Refund updatedRefund = [SELECT Id, Refund_Reference__c FROM Refund WHERE Id = :refund.Id];
+        Assert.areEqual('12345', updatedRefund.Refund_Reference__c, 'Expected Refund_Reference__c to remain unchanged');
+    }
+}

--- a/force-app/main/default/classes/AdyenRefundReferenceBatchTest.cls-meta.xml
+++ b/force-app/main/default/classes/AdyenRefundReferenceBatchTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/PostInstallScript.cls
+++ b/force-app/main/default/classes/PostInstallScript.cls
@@ -1,12 +1,18 @@
 public class PostInstallScript implements InstallHandler {
-    private static final String JOB_NAME = 'Adyen_PBL_Batch_Job';
+    private static final String ADYEN_PBL_JOB_NAME = 'Adyen_PBL_Batch_Job';
+    private static final String REFUND_REFERENCE_JOB_NAME = 'Adyen_Refund_Reference_Batch_Job';
     private static final String SCHEDULED_JOB_TYPE = '7'; // Scheduled Apex Job
 
     public void onInstall(InstallContext context) {
-        if (!isBatchJobScheduled(JOB_NAME)) {
+        if (!isBatchJobScheduled(ADYEN_PBL_JOB_NAME)) {
             String cronExp = '0 0 * * * ?';
-            System.schedule(JOB_NAME, cronExp, new AdyenPaymentLinkBatchJobScheduler());
-        } 
+            System.schedule(ADYEN_PBL_JOB_NAME, cronExp, new AdyenPaymentLinkBatchJobScheduler());
+        }
+
+        if (!isBatchJobScheduled(REFUND_REFERENCE_JOB_NAME)) {
+            String cronExp = '0 0 * * * ?';
+            System.schedule(REFUND_REFERENCE_JOB_NAME, cronExp, new AdyenRefundRefBatchJobScheduler());
+        }
     }
 
     private Boolean isBatchJobScheduled(String jobName) {
@@ -16,7 +22,6 @@ public class PostInstallScript implements InstallHandler {
             WHERE CronJobDetail.Name = :jobName 
             AND CronJobDetail.JobType = :SCHEDULED_JOB_TYPE
         ];
-
         return !scheduledJobs.isEmpty();
     }
 }

--- a/force-app/main/default/classes/PostInstallScript.cls
+++ b/force-app/main/default/classes/PostInstallScript.cls
@@ -2,16 +2,15 @@ public class PostInstallScript implements InstallHandler {
     private static final String ADYEN_PBL_JOB_NAME = 'Adyen_PBL_Batch_Job';
     private static final String REFUND_REFERENCE_JOB_NAME = 'Adyen_Refund_Reference_Batch_Job';
     private static final String SCHEDULED_JOB_TYPE = '7'; // Scheduled Apex Job
+    private static final String DEFAULT_CRON_EXPRESSION = '0 0 * * * ?';
 
     public void onInstall(InstallContext context) {
         if (!isBatchJobScheduled(ADYEN_PBL_JOB_NAME)) {
-            String cronExp = '0 0 * * * ?';
-            System.schedule(ADYEN_PBL_JOB_NAME, cronExp, new AdyenPaymentLinkBatchJobScheduler());
+            System.schedule(ADYEN_PBL_JOB_NAME, DEFAULT_CRON_EXPRESSION, new AdyenPaymentLinkBatchJobScheduler());
         }
 
         if (!isBatchJobScheduled(REFUND_REFERENCE_JOB_NAME)) {
-            String cronExp = '0 0 * * * ?';
-            System.schedule(REFUND_REFERENCE_JOB_NAME, cronExp, new AdyenRefundRefBatchJobScheduler());
+            System.schedule(REFUND_REFERENCE_JOB_NAME, DEFAULT_CRON_EXPRESSION, new AdyenRefundRefBatchJobScheduler());
         }
     }
 

--- a/force-app/main/default/classes/PostInstallScriptTest.cls
+++ b/force-app/main/default/classes/PostInstallScriptTest.cls
@@ -8,16 +8,22 @@ private class PostInstallScriptTest {
         
         // When
         Test.testInstall(postInstall, null);
-
+        
         // Then
-        List<CronTrigger> jobs = [SELECT Id FROM CronTrigger WHERE CronJobDetail.Name = 'Adyen_PBL_Batch_Job'];
-        Assert.areEqual(1, jobs.size(), 'Expected one scheduled job after fresh install');
-
+        List<CronTrigger> pblJobs = [SELECT Id FROM CronTrigger WHERE CronJobDetail.Name = 'Adyen_PBL_Batch_Job'];
+        Assert.areEqual(1, pblJobs.size(), 'Expected one Adyen_PBL_Batch_Job scheduled after fresh install');
+        
+        List<CronTrigger> refundJobs = [SELECT Id FROM CronTrigger WHERE CronJobDetail.Name = 'Adyen_Refund_Reference_Batch_Job'];
+        Assert.areEqual(1, refundJobs.size(), 'Expected one Adyen_RefundReference_Batch_Job scheduled after fresh install');
+        
         // When: Simulating an upgrade from version 1.0 to the current version
         Test.testInstall(postInstall, new Version(1, 0));
-
+        
         // Then: Ensure the job is still only scheduled once (no duplicate scheduling)
-        jobs = [SELECT Id FROM CronTrigger WHERE CronJobDetail.Name = 'Adyen_PBL_Batch_Job'];
-        Assert.areEqual(1, jobs.size(), 'Expected only one scheduled job after upgrade');
+        pblJobs = [SELECT Id FROM CronTrigger WHERE CronJobDetail.Name = 'Adyen_PBL_Batch_Job'];
+        Assert.areEqual(1, pblJobs.size(), 'Expected only one Adyen_PBL_Batch_Job after upgrade');
+        
+        refundJobs = [SELECT Id FROM CronTrigger WHERE CronJobDetail.Name = 'Adyen_Refund_Reference_Batch_Job'];
+        Assert.areEqual(1, refundJobs.size(), 'Expected only one Adyen_RefundReference_Batch_Job after upgrade');
     }
 }

--- a/force-app/main/default/objects/Refund/fields/Refund_Reference__c.field-meta.xml
+++ b/force-app/main/default/objects/Refund/fields/Refund_Reference__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Refund_Reference__c</fullName>
+    <description>Text field for the refund reference, auto-populated by the batch job for tracking</description>
+    <externalId>false</externalId>
+    <label>Refund Reference</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Automate the population of refund reference on Refund record for better tracking.
- What existing problem does this pull request solve?
The batch job syncs the refund reference from PaymentGatewayLog to Refund records


