### PR TITLE
Add button to update Named Credential URL for the production instance

### DIFF
--- a/force-app/main/default/classes/AdyenConfigPageController.cls
+++ b/force-app/main/default/classes/AdyenConfigPageController.cls
@@ -147,9 +147,63 @@ public with sharing class AdyenConfigPageController {
     
         return namedCredentials.isEmpty() ? null : namedCredentials[0];
     }
+
+    @AuraEnabled
+    public static SiteEndpointStatus getSiteEndpointStatus() {
+        SiteEndpointStatus status = new SiteEndpointStatus();
+        try {
+            ConnectApi.NamedCredential webhookNamedCredential = ConnectApi.NamedCredentials.getNamedCredential(AdyenOMSConstants.WEBHOOK_NAMED_CREDENTIAL_NAME);
+            if (webhookNamedCredential != null &&  String.isNotBlank(webhookNamedCredential.calloutUrl)) {
+                status.isNamedCredentialConfigured = true;
+
+                Site site = findSiteByUrl(webhookNamedCredential.calloutUrl);
+                if(site == null) {
+                    status.siteExists = false;
+                    return status;
+                }
+                status.siteExists = true;
+            }
+        } catch (Exception e) {
+            status.hasError = true;
+            status.errorMessage = 'Unable to verify configuration: ' + e.getMessage();
+            status.isNamedCredentialConfigured = false;
+            status.siteExists = false;
+        }
+        return status;
+    }
+
+
+    public static Site findSiteByUrl(String url) {
+        if (String.isBlank(url)) {
+            return null;
+        }
+        
+        Map<Id, Site> sites = new Map<Id, Site>([SELECT Id, Name FROM Site WHERE Status = 'Active']);  
+        List<SiteDetail> siteDetails = [SELECT SecureURL, DurableId FROM SiteDetail where DurableId IN :sites.keyset()];
+        for (SiteDetail siteDetail : siteDetails) {
+            if (siteDetail.SecureURL == url) {
+                return sites.get(siteDetail.DurableId);
+            }
+        }
+        return null;
+
+    }
     
     public class PaymentGatewayInput {
         @AuraEnabled public String externalReference { get; set; }
         @AuraEnabled public String gatewayName { get; set; }
+    }
+
+    public class SiteEndpointStatus {
+        @AuraEnabled public Boolean isNamedCredentialConfigured { get; set; }
+        @AuraEnabled public Boolean siteExists { get; set; }
+        @AuraEnabled public Boolean hasError { get; set; }
+        @AuraEnabled public String errorMessage { get; set; }
+        public SiteEndpointStatus() {
+            this.isNamedCredentialConfigured = false;
+            this.siteExists = false;
+            this.hasError = false;
+            this.errorMessage = null;
+        }
     }
 }

--- a/force-app/main/default/classes/AdyenConfigPageController.cls
+++ b/force-app/main/default/classes/AdyenConfigPageController.cls
@@ -88,6 +88,12 @@ public with sharing class AdyenConfigPageController {
         return setupUrls;
     }
 
+    @AuraEnabled
+    public static Boolean isProductionOrg() {
+        Organization org = [SELECT IsSandbox, OrganizationType FROM Organization LIMIT 1];
+        return !org.IsSandbox && org.OrganizationType != 'Developer Edition';
+    }
+
     private static PermissionSet getOrderManagementPermissionSet() {
         List<PermissionSet> permissionSets = [
             SELECT Id

--- a/force-app/main/default/classes/AdyenConfigPageControllerTest.cls
+++ b/force-app/main/default/classes/AdyenConfigPageControllerTest.cls
@@ -125,4 +125,20 @@ private class AdyenConfigPageControllerTest {
         Assert.isTrue(urls.get('omsB2cPermissionSetUrl').contains(permSet.Id));
         
     }
+
+    @isTest
+    static void testIsProductionOrg() {
+        // Given
+        Organization currentOrg = [SELECT IsSandbox, OrganizationType FROM Organization LIMIT 1];
+
+        // When
+        Test.startTest();
+        Boolean result = AdyenConfigPageController.isProductionOrg();
+        Test.stopTest();
+
+        // Then
+        
+        Boolean expectedResult = !currentOrg.IsSandbox && currentOrg.OrganizationType != 'Developer Edition';
+        System.assertEquals(expectedResult, result, 'The isProductionOrg method should correctly reflect the current org type.');
+    }
 }

--- a/force-app/main/default/classes/AdyenConfigPageControllerTest.cls
+++ b/force-app/main/default/classes/AdyenConfigPageControllerTest.cls
@@ -126,6 +126,32 @@ private class AdyenConfigPageControllerTest {
         
     }
 
+    @isTest(SeeAllData=true)
+    static void getSiteEndpointStatusTest() {
+        // Given & When
+        Test.startTest();
+        AdyenConfigPageController.SiteEndpointStatus status = AdyenConfigPageController.getSiteEndpointStatus();
+        Test.stopTest();
+        
+        // Then
+        Assert.isNotNull(status);
+        Assert.areEqual(false, status.hasError);
+        Assert.isNull(status.errorMessage);
+    }
+
+    @isTest
+    static void findSiteByUrlTest() {
+        // Given & When
+        Test.startTest();
+        Site foundSite1 = AdyenConfigPageController.findSiteByUrl(null);
+        Site foundSite2 = AdyenConfigPageController.findSiteByUrl('');
+        Test.stopTest();
+        
+        // Then
+        Assert.isNull(foundSite1);
+        Assert.isNull(foundSite2);
+    }
+
     @isTest
     static void testIsProductionOrg() {
         // Given

--- a/force-app/main/default/lwc/adyenConfigPageNamedCredential/adyenConfigPageNamedCredential.html
+++ b/force-app/main/default/lwc/adyenConfigPageNamedCredential/adyenConfigPageNamedCredential.html
@@ -8,7 +8,7 @@
                     <lightning-spinner alternative-text="Loading" size="small"></lightning-spinner>
                 </template>
                 
-                <div class="slds-box slds-is-relative" style="min-height: 300px;">
+                <div class="slds-box slds-is-relative" style="min-height: 350px; max-height: 350px;">
                     <div class="slds-m-bottom_large">
                         <div class="slds-media slds-media_center slds-p-bottom_medium slds-border_bottom">
                             <div class="slds-media__figure">
@@ -22,8 +22,8 @@
                         </div>
                         
                         <div class="slds-p-top_medium">
-                            <div class="slds-grid slds-grid_align-spread slds-p-bottom_medium">
-                                <div class="slds-col slds-size_1-of-2">
+                            <div class="slds-grid slds-gutters slds-p-bottom_medium">
+                                <div class="slds-col">
                                     <lightning-button 
                                         variant="neutral" 
                                         label="Update API Key" 
@@ -36,7 +36,7 @@
                                         class="slds-button_stretch">
                                     </lightning-button>
                                 </div>
-                                <div class="slds-col slds-size_1-of-2 slds-p-left_medium">
+                                <div class="slds-col">
                                     <lightning-button 
                                         variant="neutral" 
                                         label="Assign Permissions" 
@@ -49,6 +49,21 @@
                                         class="slds-button_stretch">
                                     </lightning-button>
                                 </div>
+                                <template if:true={isProduction}>
+                                    <div class="slds-col">
+                                        <lightning-button 
+                                            variant="neutral" 
+                                            label="Update URL" 
+                                            icon-name="utility:world"
+                                            icon-position="left"
+                                            data-credential="AdyenCheckout"
+                                            data-buttontype="updateUrl"
+                                            onmouseover={handleButtonMouseOver}
+                                            onclick={handleUpdateUrl} 
+                                            class="slds-button_stretch">
+                                        </lightning-button>
+                                    </div>
+                                </template>
                             </div>
                         </div>
                     </div>
@@ -66,8 +81,8 @@
                         </div>
 
                         <div class="slds-p-top_medium">
-                            <div class="slds-grid slds-grid_align-spread slds-p-bottom_medium">
-                                <div class="slds-col slds-size_1-of-2">
+                            <div class="slds-grid slds-gutters slds-p-bottom_medium">
+                                <div class="slds-col">
                                     <lightning-button 
                                         variant="neutral" 
                                         label="Update API Key" 
@@ -80,7 +95,7 @@
                                         class="slds-button_stretch">
                                     </lightning-button>
                                 </div>
-                                <div class="slds-col slds-size_1-of-2 slds-p-left_medium">
+                                <div class="slds-col">
                                     <lightning-button 
                                         variant="neutral" 
                                         label="Assign Permissions" 
@@ -93,6 +108,21 @@
                                         class="slds-button_stretch">
                                     </lightning-button>
                                 </div>
+                                <template if:true={isProduction}>
+                                    <div class="slds-col">
+                                        <lightning-button 
+                                            variant="neutral" 
+                                            label="Update URL" 
+                                            icon-name="utility:world"
+                                            icon-position="left"
+                                            data-credential="AdyenManagementAPI"
+                                            data-buttontype="updateUrl"
+                                            onmouseover={handleButtonMouseOver}
+                                            onclick={handleUpdateUrl} 
+                                            class="slds-button_stretch">
+                                        </lightning-button>
+                                    </div>
+                                </template>
                             </div>
                         </div>
                     </div>
@@ -101,10 +131,10 @@
         </div>
         
         <div class="slds-col slds-size_1-of-2">
-            <div class="slds-box slds-box_x-small slds-is-relative">
+            <div class="slds-box slds-box_x-small slds-m-bottom_medium slds-is-relative">
                 <h2 class="slds-text-heading_medium slds-m-bottom_medium">Instructions</h2>
                 
-                <div class="slds-box slds-is-relative" style="min-height: 300px;">
+                <div class="slds-box slds-is-relative slds-scrollable" style="min-height: 350px; max-height: 350px;">
                     <template if:true={showDefaultInstructions}>
                         <div class="slds-p-around_medium">
                             <h3 class="slds-text-heading_small slds-m-bottom_small">
@@ -170,6 +200,38 @@
                                     <li>Select <strong>Assign</strong>.</li>
                                 </ol>
                             </template>
+                        </div>
+                    </template>
+
+                    <template if:true={showUpdateUrlInstructions}>
+                        <div class="slds-p-around_medium">
+                            <h3 class="slds-text-heading_small slds-m-bottom_small">Update URL for {currentCredential}</h3>
+                            <div class="slds-box slds-box_x-small slds-theme_shade slds-m-bottom_medium">
+                                <p class="slds-text-body_small">
+                                    <strong>Production Environment Detected:</strong> Update the Named Credential URL from test endpoint to live endpoint for production use.
+                                </p>
+                            </div>
+                            <ol class="slds-list_ordered slds-m-left_medium">
+                                <li>On the {currentCredential} Named Credential page, click <strong>Edit</strong>.</li>
+                                <li>In the <strong>URL</strong> field, update the endpoint URL:
+                                    <ul class="slds-list_dotted slds-m-left_medium slds-m-top_xx-small">
+                                        <template if:true={isManagementAPI}>
+                                            <li>Change from: <code>https://management-test.adyen.com</code></li>
+                                            <li>Change to: <code>https://management-live.adyen.com</code></li>
+                                        </template>
+                                        <template if:false={isManagementAPI}>
+                                            <li>Change from: <code>https://checkout-test.adyen.com</code></li>
+                                            <li>Change to: <code>https://[YOUR_LIVE_PREFIX]-checkout-live.adyenpayments.com/checkout.</code>  Get your live prefix from the live Customer Area.</li>
+                                        </template>
+                                    </ul>
+                                </li>
+                                <li>Click <strong>Save</strong>.</li>
+                            </ol>
+                            <div class="slds-box slds-box_x-small slds-theme_warning slds-m-top_medium">
+                                <p class="slds-text-body_small">
+                                    <strong>Important:</strong> Ensure you have production API credentials configured before updating to live endpoints.
+                                </p>
+                            </div>
                         </div>
                     </template> 
                 </div>

--- a/force-app/main/default/lwc/adyenConfigPageNamedCredential/adyenConfigPageNamedCredential.js
+++ b/force-app/main/default/lwc/adyenConfigPageNamedCredential/adyenConfigPageNamedCredential.js
@@ -1,9 +1,11 @@
 import { LightningElement, track } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getSetupPageUrls from '@salesforce/apex/AdyenConfigPageController.getSetupPageUrls';
+import isProductionOrg from '@salesforce/apex/AdyenConfigPageController.isProductionOrg';
 
 export default class AdyenConfigPageNamedCredential extends LightningElement {
     @track setupUrls = {};
+    isProduction = false;
     showSpinner = false;
     stepName = 'namedCredential';
     
@@ -22,12 +24,19 @@ export default class AdyenConfigPageNamedCredential extends LightningElement {
         return this.currentInstructionSet === 'permissions';
     }
 
+    get showUpdateUrlInstructions() {
+        return this.currentInstructionSet === 'updateUrl';
+    }
+
     get isManagementAPI() {
         return this.currentCredential === 'AdyenManagementAPI';
     }
     
     async connectedCallback() {
-        await this.fetchSetupUrls();
+        await Promise.all([
+            this.fetchSetupUrls(),
+            this.checkProductionOrg()
+        ]);
     }
     
     async fetchSetupUrls() {
@@ -40,9 +49,32 @@ export default class AdyenConfigPageNamedCredential extends LightningElement {
             this.showSpinner = false;
         }
     }
+
+    async checkProductionOrg() {
+        try {
+            this.isProduction = await isProductionOrg();
+        } catch (error) {
+            this.handleError(error);
+        }
+    }
     
     handleUpdateApiKey(event) {
-        const credentialName = event.currentTarget.dataset.credential;
+        this.openNamedCredentialSetup(event.currentTarget.dataset.credential);
+    }
+
+    handleAssignPermissions() {
+        if (this.setupUrls.permissionSet) {
+            window.open(this.setupUrls.permissionSet, '_blank');
+        } else {
+            this.showToast('Error', 'Unable to open Permission Set setup page.', 'error');
+        }
+    }
+
+    handleUpdateUrl(event) {
+        this.openNamedCredentialSetup(event.currentTarget.dataset.credential);
+    }
+
+    openNamedCredentialSetup(credentialName) {
         const credentialUrls = {
             'AdyenCheckout': this.setupUrls.checkoutNamedCredential,
             'AdyenManagementAPI': this.setupUrls.managementApiNamedCredential
@@ -54,14 +86,6 @@ export default class AdyenConfigPageNamedCredential extends LightningElement {
             window.open(setupUrl, '_blank');
         } else {
             this.showToast('Error', 'Unable to open Named Credential setup page.', 'error');
-        }
-    }
-
-    handleAssignPermissions() {
-        if (this.setupUrls.permissionSet) {
-            window.open(this.setupUrls.permissionSet, '_blank');
-        } else {
-            this.showToast('Error', 'Unable to open Permission Set setup page.', 'error');
         }
     }
     

--- a/force-app/main/default/lwc/adyenConfigPageSiteEndpoint/adyenConfigPageSiteEndpoint.html
+++ b/force-app/main/default/lwc/adyenConfigPageSiteEndpoint/adyenConfigPageSiteEndpoint.html
@@ -8,66 +8,88 @@
                     <lightning-spinner alternative-text="Loading" size="small"></lightning-spinner>
                 </template>
                 
-                <div class="slds-box slds-is-relative" style="min-height: 300px;">
-                    <div class="slds-m-bottom_large">
-                        <div class="slds-media slds-media_center slds-p-bottom_medium slds-border_bottom">
-                            <div class="slds-media__figure">
-                                <span class="slds-icon_container slds-icon-standard-account">
-                                    <lightning-icon icon-name="standard:apex_plugin" size="small"></lightning-icon>
-                                </span>
-                            </div>
-                            <div class="slds-media__body">
-                                <div class="slds-text-heading_small slds-text-title_bold">Salesforce Site Endpoint</div>
-                                <div class="slds-text-body_small">Create a new Salesforce Site for the webhook notifications</div>
-                            </div>
-                        </div>
-                        
-                        <div class="slds-grid slds-grid_align-spread slds-p-vertical_medium">
-                            <div class="slds-col slds-size_3-of-5">
-                                <lightning-button 
-                                    variant="neutral" 
-                                    label="Setup Salesforce Site Endpoint"
-                                    icon-name="utility:link"
-                                    icon-position="left"
-                                    data-action="siteEndpoint"
-                                    data-instructiontype="siteEndpoint"
-                                    onmouseover={handleButtonMouseOver}
-                                    onclick={handleSetupSiteEndpoint} 
-                                    stretch>
-                                </lightning-button>
+                <div class="slds-box slds-is-relative" style="min-height: 350px; max-height: 350px;">
+                    <template if:true={showExistingConfigInfo}>
+                        <div class="slds-box slds-theme_info slds-p-around_medium">
+                            <div class="slds-media">
+                                <div class="slds-media__figure">
+                                    <lightning-icon icon-name="utility:info" alternative-text="Info" variant="inverse" size="small"></lightning-icon>
+                                </div>
+                                <div class="slds-media__body">
+                                    <p>The Named Credential is already configured, and a site exists. Verify the configuration and permissions per the provided instructions.</p>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                        <div class="slds-grid slds-grid_align-end slds-m-top_medium">
+                            <lightning-button 
+                                variant="brand" 
+                                label="Continue"
+                                onclick={handleProceed}>
+                            </lightning-button>
+                        </div>
+                    </template>
 
-                    <div class="slds-m-top_x-large">
-                        <div class="slds-media slds-media_center slds-p-bottom_medium slds-border_bottom">
-                            <div class="slds-media__figure">
-                                <span class="slds-icon_container slds-icon-standard-account">
-                                    <lightning-icon icon-name="standard:apex_plugin" size="small"></lightning-icon>
-                                </span>
+                    <template if:false={showExistingConfigInfo}>
+                        <div class="slds-m-bottom_large">
+                            <div class="slds-media slds-media_center slds-p-bottom_medium slds-border_bottom">
+                                <div class="slds-media__figure">
+                                    <span class="slds-icon_container slds-icon-standard-account">
+                                        <lightning-icon icon-name="standard:apex_plugin" size="small"></lightning-icon>
+                                    </span>
+                                </div>
+                                <div class="slds-media__body">
+                                    <div class="slds-text-heading_small slds-text-title_bold">Salesforce Site Endpoint</div>
+                                    <div class="slds-text-body_small">Create a new Salesforce Site for the webhook notifications</div>
+                                </div>
                             </div>
-                            <div class="slds-media__body">
-                                <div class="slds-text-heading_small slds-text-title_bold">Update Named Credential</div>
-                                <div class="slds-text-body_small">Add the new site URL to your Named Credential</div>
+                            
+                            <div class="slds-grid slds-grid_align-spread slds-p-vertical_medium">
+                                <div class="slds-col slds-size_3-of-5">
+                                    <lightning-button 
+                                        variant="neutral" 
+                                        label="Setup Salesforce Site Endpoint"
+                                        icon-name="utility:link"
+                                        icon-position="left"
+                                        data-action="siteEndpoint"
+                                        data-instructiontype="siteEndpoint"
+                                        onmouseover={handleButtonMouseOver}
+                                        onclick={handleSetupSiteEndpoint} 
+                                        stretch>
+                                    </lightning-button>
+                                </div>
                             </div>
                         </div>
-                        
-                        <div class="slds-grid slds-grid_align-spread slds-p-vertical_medium">
-                            <div class="slds-col slds-size_3-of-5">
-                                <lightning-button 
-                                    variant="neutral" 
-                                    label="Update Site URL on Named Credential"
-                                    icon-name="utility:link"
-                                    icon-position="left"
-                                    data-action="updateUrl"
-                                    data-instructiontype="updateUrl"
-                                    onmouseover={handleButtonMouseOver}
-                                    onclick={handleUpdateSiteUrl} 
-                                    stretch>
-                                </lightning-button>
+
+                        <div class="slds-m-top_x-large">
+                            <div class="slds-media slds-media_center slds-p-bottom_medium slds-border_bottom">
+                                <div class="slds-media__figure">
+                                    <span class="slds-icon_container slds-icon-standard-account">
+                                        <lightning-icon icon-name="standard:apex_plugin" size="small"></lightning-icon>
+                                    </span>
+                                </div>
+                                <div class="slds-media__body">
+                                    <div class="slds-text-heading_small slds-text-title_bold">Update Named Credential</div>
+                                    <div class="slds-text-body_small">Add the new site URL to your Named Credential</div>
+                                </div>
+                            </div>
+                            
+                            <div class="slds-grid slds-grid_align-spread slds-p-vertical_medium">
+                                <div class="slds-col slds-size_3-of-5">
+                                    <lightning-button 
+                                        variant="neutral" 
+                                        label="Update Site URL on Named Credential"
+                                        icon-name="utility:link"
+                                        icon-position="left"
+                                        data-action="updateUrl"
+                                        data-instructiontype="updateUrl"
+                                        onmouseover={handleButtonMouseOver}
+                                        onclick={handleUpdateSiteUrl} 
+                                        stretch>
+                                    </lightning-button>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    </template>
                 </div>
             </div>
         </div>
@@ -76,7 +98,7 @@
             <div class="slds-box slds-box_x-small slds-is-relative">
                 <h2 class="slds-text-heading_medium slds-m-bottom_medium">Instructions</h2>
                 
-                <div class="slds-box slds-is-relative slds-scrollable" style="min-height: 300px; max-height: 300px;">
+                <div class="slds-box slds-is-relative slds-scrollable" style="min-height: 350px; max-height: 350px;">
                     <template if:true={showDefaultInstructions}>
                         <div class="slds-p-around_medium">
                             <h3 class="slds-text-heading_small slds-m-bottom_small">
@@ -115,7 +137,6 @@
                                 <li>On the Named Credential page, click on Edit. This opens a modal window.</li>
                                 <li>In the “URL” field, Enter the Site URL that was created on the previous step.</li>
                                 <li>Make sure that the “Enable for Callouts” checkbox is checked.</li>
-                                <li>Update the URL field with the Site URL you copied from the previous step.</li>
                                 <li>Click on Save</li>
                             </ol>
                         </div>

--- a/force-app/main/default/lwc/adyenConfigPageSiteEndpoint/adyenConfigPageSiteEndpoint.js
+++ b/force-app/main/default/lwc/adyenConfigPageSiteEndpoint/adyenConfigPageSiteEndpoint.js
@@ -1,12 +1,15 @@
 import { LightningElement, track } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getSetupPageUrls from '@salesforce/apex/AdyenConfigPageController.getSetupPageUrls';
+import getSiteEndpointStatus from '@salesforce/apex/AdyenConfigPageController.getSiteEndpointStatus';
 
 export default class AdyenConfigPageSiteEndpoint extends LightningElement {
     @track setupUrls = {};
     showSpinner = false;
     stepName = 'siteUrl';
     currentInstructionSet = 'default';
+    isAlreadyConfigured = false;
+    acknowledgedExistingConfig = false;
     
     get showDefaultInstructions() {
         return this.currentInstructionSet === 'default';
@@ -19,22 +22,38 @@ export default class AdyenConfigPageSiteEndpoint extends LightningElement {
     get showUpdateUrlInstructions() {
         return this.currentInstructionSet === 'updateUrl';
     }
-    
-    connectedCallback() {
-        this.fetchSetupUrls();
+
+    get showExistingConfigInfo() {
+        return this.isAlreadyConfigured && !this.acknowledgedExistingConfig;
     }
     
-    async fetchSetupUrls() {
-           this.showSpinner = true;
-           try {
-               this.setupUrls = await getSetupPageUrls();
-           } catch (error) {
-               this.handleError(error);
-           } finally {
-               this.showSpinner = false;
-           }
-       }
+    connectedCallback() {
+        this.loadInitialData();
+    }
     
+    async loadInitialData() {
+        this.showSpinner = true;
+        try {
+            const [urls, status] = await Promise.all([
+                getSetupPageUrls(),
+                getSiteEndpointStatus()
+            ]);
+            this.setupUrls = urls;
+            if (status.hasError) {
+                this.showToast('Error', status.errorMessage, 'error');
+                return;
+            }
+   
+            if (status.isNamedCredentialConfigured && status.siteExists) {
+                this.isAlreadyConfigured = true;
+            }
+        } catch (error) {
+            this.handleError(error);
+        } finally {
+            this.showSpinner = false;
+        }
+    }
+
     handleSetupSiteEndpoint() {
         if (this.setupUrls.siteSetup) {
             window.open(this.setupUrls.siteSetup, '_blank');
@@ -56,6 +75,10 @@ export default class AdyenConfigPageSiteEndpoint extends LightningElement {
         this.currentInstructionSet = instructionType;
     }
     
+    handleProceed() {
+        this.acknowledgedExistingConfig = true;
+    }
+
     handleError(error) {
         const errorMessage = error.body ? error.body.message : error.message;
         this.showToast('Error', errorMessage, 'error');

--- a/force-app/main/default/lwc/adyenConfigPageWebhookSetup/adyenConfigPageWebhookSetup.html
+++ b/force-app/main/default/lwc/adyenConfigPageWebhookSetup/adyenConfigPageWebhookSetup.html
@@ -8,7 +8,7 @@
                     <lightning-spinner alternative-text="Loading" size="small"></lightning-spinner>
                 </template>
                 
-                <div class="slds-box slds-is-relative" style="min-height: 300px; max-height: 300px;">
+                <div class="slds-box slds-is-relative" style="min-height: 350px; max-height: 350px;">
                     <div class="slds-m-bottom_large">
                         <template if:true={accountSetupContext}>
                             <div class="slds-media slds-media_center slds-p-bottom_medium slds-border_bottom">
@@ -303,7 +303,7 @@
             <div class="slds-box slds-box_x-small slds-is-relative">
                 <h2 class="slds-text-heading_medium slds-m-bottom_medium">Instructions</h2>
                 
-                <div class="slds-box slds-is-relative slds-scrollable" style="min-height: 300px; max-height: 300px;">
+                <div class="slds-box slds-is-relative slds-scrollable" style="min-height: 350px; max-height: 350px;">
                     <div class="slds-p-around_medium">
                         <h3 class="slds-text-heading_small slds-m-bottom_small">
                             Webhook Setup


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
To provide a button that allows updating the Named Credential URL in the production instance.
- What existing problem does this pull request solve?
An additional button is rendered in the production instance to update the Named Credential URL.