### PR TITLE
[SFI-1491] Add capturePspReference to Scalapay refund requests

### DIFF
--- a/force-app/main/default/classes/AdyenOMSConstants.cls
+++ b/force-app/main/default/classes/AdyenOMSConstants.cls
@@ -26,6 +26,8 @@ public with sharing class AdyenOMSConstants {
 
     public static final Set<String> OPEN_INVOICE_METHODS = new Set<String>{'klarna', 'afterpay', 'ratepay', 'facilypay', 'zip', 'affirm', 'atome', 'walley', 'clearpay', 'riverty'};
 
+    public static final Set<String> PAYMENT_METHODS_REQUIRING_CAPTURE_PSP_REFERENCE = new Set<String>{'paypal', 'scalapay'};
+
     public static final Set<String> VALID_NOTIFICATION_TYPES = new Set<String>{
         AdyenConstants.NOTIFICATION_REQUEST_TYPE_CAPTURE,
         AdyenConstants.NOTIFICATION_REQUEST_TYPE_REFUND,

--- a/force-app/main/default/classes/AdyenRefundHelper.cls
+++ b/force-app/main/default/classes/AdyenRefundHelper.cls
@@ -36,12 +36,23 @@ public with sharing class AdyenRefundHelper {
     @TestVisible
     private static CheckoutRefundRequest createRefundRequest(CommercePayments.ReferencedRefundRequest refundRequest, Payment payment, Adyen_Adapter__mdt adyenAdapter) {
         CheckoutRefundRequest modRequest = (CheckoutRefundRequest)AdyenPaymentUtility.createModificationRequest(refundRequest, payment.CurrencyIsoCode, adyenAdapter);
-        //Only for Paypal Refunds - Capture reference must be a substring of refund reference
         if (String.isNotBlank(payment.PaymentAuthorization?.Adyen_Payment_Method_Variant__c)) {
-            if (payment.PaymentAuthorization.Adyen_Payment_Method_Variant__c.equalsIgnoreCase('Paypal') && String.isNotBlank(payment.GatewayRefDetails)) {
-                String refundReference = modRequest.getReference() + payment.GatewayRefDetails;
-                modRequest.setReference(refundReference);
-                modRequest.capturePspReference = payment.GatewayRefNumber;
+            String paymentMethodVariant = payment.PaymentAuthorization.Adyen_Payment_Method_Variant__c;
+            if (String.isNotBlank(paymentMethodVariant)) {
+                Boolean requiresCapturePsp = false;
+                for (String method : AdyenOMSConstants.PAYMENT_METHODS_REQUIRING_CAPTURE_PSP_REFERENCE) {
+                    if (paymentMethodVariant.containsIgnoreCase(method)) {
+                        requiresCapturePsp = true;
+                        break;
+                    }
+                }
+                if (requiresCapturePsp) {
+                    modRequest.capturePspReference = payment.GatewayRefNumber;
+                    if (paymentMethodVariant.containsIgnoreCase('paypal') && String.isNotBlank(payment.GatewayRefDetails)) {
+                        String refundReference = modRequest.getReference() + payment.GatewayRefDetails;
+                        modRequest.setReference(refundReference);
+                    }
+                }
             }
         }
         // Line items required for partial refunds for Open Invoice methods

--- a/force-app/main/default/classes/AdyenRefundHelperTest.cls
+++ b/force-app/main/default/classes/AdyenRefundHelperTest.cls
@@ -23,4 +23,27 @@ private class AdyenRefundHelperTest {
         Assert.isNotNull(modificationRequest.capturePspReference);
         Assert.areEqual(TestDataFactory.TEST_PSP_REFERENCE, modificationRequest.capturePspReference);
     }
+
+    @IsTest
+    static void createScalapayRefundRequestTest() {
+        // Given
+        Account acct = TestDataFactory.createAccount();
+        insert acct;
+        CardPaymentMethod cardPayMeth = TestDataFactory.createCardPaymentMethod();
+        insert cardPayMeth;
+        PaymentAuthorization payAuth = TestDataFactory.createPaymentAuthorization(acct.Id, cardPayMeth.Id, null, null, TestDataFactory.TEST_PSP_REFERENCE);
+        payAuth.Adyen_Payment_Method_Variant__c = 'scalapay_3x';
+        insert payAuth;
+        Payment payment = TestDataFactory.createPayment(acct.Id, cardPayMeth.Id, null, payAuth.Id, null);
+        insert payment;
+        payment.PaymentAuthorization = [SELECT Adyen_Payment_Method_Variant__c FROM PaymentAuthorization WHERE Id = :payAuth.Id];
+        CommercePayments.ReferencedRefundRequest refundRequest = new CommercePayments.ReferencedRefundRequest(TestDataFactory.TEST_PRICE_AMOUNT, payment.Id);
+
+        // Then
+        CheckoutRefundRequest modificationRequest = AdyenRefundHelper.createRefundRequest(refundRequest, payment, AdyenPaymentUtility.chooseAdapterWithFallBack(null));
+
+        // When
+        Assert.isNotNull(modificationRequest.capturePspReference);
+        Assert.areEqual(TestDataFactory.TEST_PSP_REFERENCE, modificationRequest.capturePspReference);
+    }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
This PR adds the missing required capturePspReference field for the refunds of partially captured payments for Scalapay.
